### PR TITLE
fix: initialize server-side rwnd from peer INIT advertised_receiver_w…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+  * Fix server-side rwnd initialization from INIT #28 
+
 # 0.7.0
 
   * Mark some types non_exhaustive (breaking) #26

--- a/src/association/association_test.rs
+++ b/src/association/association_test.rs
@@ -360,6 +360,17 @@ fn handle_init_test(name: &str, initial_state: AssociationState, expect_err: boo
         name
     );
     assert!(a.use_forward_tsn, "{} should be set to true", name);
+    assert_eq!(
+        512 * 1024,
+        a.rwnd,
+        "{} rwnd should be initialized from peer's advertised_receiver_window_credit",
+        name
+    );
+    assert_eq!(
+        a.rwnd, a.ssthresh,
+        "{} ssthresh should be initialized to rwnd",
+        name
+    );
 }
 
 #[test]


### PR DESCRIPTION
…indow_credit

The server-side Association's rwnd field was never initialized from the peer's INIT chunk advertised_receiver_window_credit. It stayed at the default value of 0 until the first SACK was received.

This caused all server DATA sending to be blocked by the rwnd check in pop_pending_data_chunks_to_send() (data_len > self.rwnd => N > 0 => true). Only zero-window probes (when inflight_queue is empty) could bypass this.

In practice, the server's first DATA response was always delayed by the peer's delayed ACK timer (~200ms for all major SCTP implementations), because only after receiving that SACK would handle_sack() set rwnd to the actual value.

The fix mirrors what handle_init_ack already does for the client side:
  self.rwnd = i.advertised_receiver_window_credit;
  self.ssthresh = self.rwnd;

Also adds assertions to the existing handle_init test to verify rwnd and ssthresh are properly initialized.