### PR TITLE
Add support for out of band negotiation for SNAP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Unreleased
+  * Add support for out of band negotiation for SNAP #34
   * Deduplicate incoming RE-CONFIG requests to prevent new stream destruction #30
   * Replace lazy_static with std::sync::LazyLock in tests #41
   * Preparation for no_std + alloc #36

--- a/src/association/association_test.rs
+++ b/src/association/association_test.rs
@@ -1,3 +1,6 @@
+use crate::chunk::{Chunk, chunk_init::ChunkInit};
+use crate::config::generate_snap_token;
+
 use super::*;
 
 const ACCEPT_CH_SIZE: usize = 16;
@@ -631,4 +634,382 @@ fn test_assoc_max_message_size_asymmetric() -> Result<()> {
     }
 
     Ok(())
+}
+
+#[test]
+fn test_generate_out_of_band_init() {
+    let config = TransportConfig::default();
+    let init_bytes = generate_snap_token(&config).unwrap();
+
+    // Parse it back to validate
+    let parsed = ChunkInit::unmarshal(&init_bytes).unwrap();
+
+    assert!(!parsed.is_ack, "Should be INIT, not INIT ACK");
+    assert!(parsed.initiate_tag != 0, "Initiate tag should not be zero");
+    // Token always advertises u16::MAX for stream counts;
+    // actual limits are applied from TransportConfig during negotiation.
+    assert_eq!(
+        parsed.num_outbound_streams,
+        u16::MAX,
+        "Outbound streams should always be u16::MAX in token"
+    );
+    assert_eq!(
+        parsed.num_inbound_streams,
+        u16::MAX,
+        "Inbound streams should always be u16::MAX in token"
+    );
+    assert_eq!(
+        parsed.advertised_receiver_window_credit,
+        config.max_receive_buffer_size(),
+        "ARWND should match config"
+    );
+}
+
+#[test]
+fn test_generate_out_of_band_init_with_custom_config() {
+    let config = TransportConfig::default()
+        .with_max_receive_buffer_size(2_000_000)
+        .with_max_num_outbound_streams(256)
+        .with_max_num_inbound_streams(512);
+
+    let init_bytes = generate_snap_token(&config).unwrap();
+    let parsed = ChunkInit::unmarshal(&init_bytes).unwrap();
+
+    // Token always advertises u16::MAX for stream counts;
+    // actual limits are applied from TransportConfig during negotiation.
+    assert_eq!(parsed.num_outbound_streams, u16::MAX);
+    assert_eq!(parsed.num_inbound_streams, u16::MAX);
+    assert_eq!(parsed.advertised_receiver_window_credit, 2_000_000);
+}
+
+#[test]
+fn test_generate_out_of_band_init_uniqueness() {
+    // Each call to generate_snap_token creates a new INIT with unique random tags.
+    let config1 = TransportConfig::default();
+    let config2 = TransportConfig::default();
+
+    let init1 = generate_snap_token(&config1).unwrap();
+    let init2 = generate_snap_token(&config2).unwrap();
+
+    let parsed1 = ChunkInit::unmarshal(&init1).unwrap();
+    let parsed2 = ChunkInit::unmarshal(&init2).unwrap();
+
+    // Initiate tags should be different (random)
+    assert_ne!(
+        parsed1.initiate_tag, parsed2.initiate_tag,
+        "Initiate tags should be unique across calls"
+    );
+
+    // Initial TSNs should be different (random)
+    assert_ne!(
+        parsed1.initial_tsn, parsed2.initial_tsn,
+        "Initial TSNs should be unique across calls"
+    );
+}
+
+#[test]
+fn test_out_of_band_association_creation() {
+    let local_config = Arc::new(TransportConfig::default());
+    let remote_config = TransportConfig::default();
+    let max_payload_size = 1200;
+
+    let local_init_bytes = generate_snap_token(&local_config).unwrap();
+    let remote_init_bytes = generate_snap_token(&remote_config).unwrap();
+
+    let local_init = ChunkInit::unmarshal(&local_init_bytes).unwrap();
+    let remote_init = ChunkInit::unmarshal(&remote_init_bytes).unwrap();
+
+    let remote_addr: SocketAddr = "192.168.1.1:5000".parse().unwrap();
+
+    let assoc = Association::new_with_out_of_band_init(
+        local_config.clone(),
+        max_payload_size,
+        remote_addr,
+        None,
+        local_init.clone(),
+        remote_init.clone(),
+    )
+    .expect("Should create out-of-band init association");
+
+    // Verify the association is in ESTABLISHED state
+    assert_eq!(
+        assoc.state(),
+        AssociationState::Established,
+        "Out-of-band init association should be in ESTABLISHED state"
+    );
+
+    // Verify handshake is marked complete
+    assert!(
+        assoc.handshake_completed,
+        "Out-of-band init association should have handshake completed"
+    );
+
+    // Verify verification tags
+    assert_eq!(
+        assoc.my_verification_tag, local_init.initiate_tag,
+        "My verification tag should match local init"
+    );
+    assert_eq!(
+        assoc.peer_verification_tag, remote_init.initiate_tag,
+        "Peer verification tag should match remote init"
+    );
+
+    // Verify TSN setup
+    assert_eq!(
+        assoc.my_next_tsn, local_init.initial_tsn,
+        "My next TSN should match local init"
+    );
+    assert_eq!(
+        assoc.peer_last_tsn,
+        remote_init.initial_tsn.wrapping_sub(1),
+        "Peer last TSN should be remote init TSN - 1"
+    );
+
+    // Verify rwnd
+    assert_eq!(
+        assoc.rwnd, remote_init.advertised_receiver_window_credit,
+        "rwnd should match remote advertised credit"
+    );
+}
+
+#[test]
+fn test_out_of_band_association_stream_negotiation() {
+    let config = Arc::new(
+        TransportConfig::default()
+            .with_max_num_outbound_streams(100)
+            .with_max_num_inbound_streams(200),
+    );
+
+    // Remote uses default config — token always advertises u16::MAX
+    let remote_config = TransportConfig::default();
+
+    let local_init_bytes = generate_snap_token(&config).unwrap();
+    let remote_init_bytes = generate_snap_token(&remote_config).unwrap();
+
+    let local_init = ChunkInit::unmarshal(&local_init_bytes).unwrap();
+    let remote_init = ChunkInit::unmarshal(&remote_init_bytes).unwrap();
+
+    // Token always advertises u16::MAX for stream counts
+    assert_eq!(local_init.num_outbound_streams, u16::MAX);
+    assert_eq!(local_init.num_inbound_streams, u16::MAX);
+    assert_eq!(remote_init.num_outbound_streams, u16::MAX);
+    assert_eq!(remote_init.num_inbound_streams, u16::MAX);
+
+    let remote_addr: SocketAddr = "192.168.1.1:5000".parse().unwrap();
+
+    let assoc = Association::new_with_out_of_band_init(
+        config.clone(),
+        1200,
+        remote_addr,
+        None,
+        local_init,
+        remote_init,
+    )
+    .expect("Should create out-of-band init association");
+
+    // Stream limits should be clamped by the local config, since the
+    // remote token always offers u16::MAX.
+    // my_max_num_outbound_streams = min(config.max_out=100, remote_in=MAX) = 100
+    assert_eq!(
+        assoc.my_max_num_outbound_streams, 100,
+        "Outbound streams should be clamped by local config"
+    );
+
+    // my_max_num_inbound_streams = min(config.max_in=200, remote_out=MAX) = 200
+    assert_eq!(
+        assoc.my_max_num_inbound_streams, 200,
+        "Inbound streams should be clamped by local config"
+    );
+}
+
+#[test]
+fn test_out_of_band_connected_event() {
+    let local_config = Arc::new(TransportConfig::default());
+    let remote_config = TransportConfig::default();
+
+    let local_init_bytes = generate_snap_token(&local_config).unwrap();
+    let remote_init_bytes = generate_snap_token(&remote_config).unwrap();
+
+    let local_init = ChunkInit::unmarshal(&local_init_bytes).unwrap();
+    let remote_init = ChunkInit::unmarshal(&remote_init_bytes).unwrap();
+
+    let remote_addr: SocketAddr = "192.168.1.1:5000".parse().unwrap();
+
+    let mut assoc = Association::new_with_out_of_band_init(
+        local_config.clone(),
+        1200,
+        remote_addr,
+        None,
+        local_init,
+        remote_init,
+    )
+    .expect("Should create out-of-band init association");
+
+    // Poll should return a Connected event
+    let event = assoc.poll();
+    assert!(
+        matches!(event, Some(Event::Connected)),
+        "Should emit Connected event, got {:?}",
+        event
+    );
+}
+
+#[test]
+fn test_out_of_band_symmetric_setup() {
+    // Test that both sides of an out-of-band init association work correctly
+    let config_a = Arc::new(TransportConfig::default());
+    let config_b = Arc::new(TransportConfig::default());
+
+    let init_a_bytes = generate_snap_token(&config_a).unwrap();
+    let init_b_bytes = generate_snap_token(&config_b).unwrap();
+
+    let init_a = ChunkInit::unmarshal(&init_a_bytes).unwrap();
+    let init_b = ChunkInit::unmarshal(&init_b_bytes).unwrap();
+
+    let addr_a: SocketAddr = "192.168.1.1:5000".parse().unwrap();
+    let addr_b: SocketAddr = "192.168.1.2:5000".parse().unwrap();
+
+    // Create association A (local=A, remote=B)
+    let assoc_a = Association::new_with_out_of_band_init(
+        config_a.clone(),
+        1200,
+        addr_b,
+        None,
+        init_a.clone(),
+        init_b.clone(),
+    )
+    .expect("Should create association A");
+
+    // Create association B (local=B, remote=A)
+    let assoc_b = Association::new_with_out_of_band_init(
+        config_b.clone(),
+        1200,
+        addr_a,
+        None,
+        init_b.clone(),
+        init_a.clone(),
+    )
+    .expect("Should create association B");
+
+    // Verify both are in ESTABLISHED state
+    assert_eq!(assoc_a.state(), AssociationState::Established);
+    assert_eq!(assoc_b.state(), AssociationState::Established);
+
+    // Verify verification tags are cross-matched
+    assert_eq!(assoc_a.my_verification_tag, assoc_b.peer_verification_tag);
+    assert_eq!(assoc_b.my_verification_tag, assoc_a.peer_verification_tag);
+}
+
+#[test]
+fn test_out_of_band_with_forward_tsn_support() {
+    let local_config = Arc::new(TransportConfig::default());
+    let remote_config = TransportConfig::default();
+
+    let local_init_bytes = generate_snap_token(&local_config).unwrap();
+    let remote_init_bytes = generate_snap_token(&remote_config).unwrap();
+
+    let local_init = ChunkInit::unmarshal(&local_init_bytes).unwrap();
+    let remote_init = ChunkInit::unmarshal(&remote_init_bytes).unwrap();
+
+    // Verify supported extensions are present
+    let mut has_forward_tsn = false;
+    for param in &local_init.params {
+        if let Some(ext) = param
+            .as_any()
+            .downcast_ref::<crate::param::param_supported_extensions::ParamSupportedExtensions>(
+        ) {
+            for ct in &ext.chunk_types {
+                if *ct == crate::chunk::chunk_type::CT_FORWARD_TSN {
+                    has_forward_tsn = true;
+                }
+            }
+        }
+    }
+    assert!(
+        has_forward_tsn,
+        "Generated INIT should include ForwardTSN support"
+    );
+
+    let remote_addr: SocketAddr = "192.168.1.1:5000".parse().unwrap();
+
+    let assoc = Association::new_with_out_of_band_init(
+        local_config.clone(),
+        1200,
+        remote_addr,
+        None,
+        local_init,
+        remote_init,
+    )
+    .expect("Should create out-of-band init association");
+
+    assert!(
+        assoc.use_forward_tsn,
+        "Out-of-band init association should have ForwardTSN enabled"
+    );
+}
+
+#[test]
+fn test_out_of_band_initial_tsn_zero_wrap() {
+    // Test edge case where initial TSN is 0 (wraps to MAX)
+    let config = Arc::new(TransportConfig::default());
+
+    let local_init_bytes = generate_snap_token(&config).unwrap();
+    let mut remote_init = ChunkInit::unmarshal(&local_init_bytes).unwrap();
+
+    // Set initial TSN to 0 to test the edge case
+    remote_init.initial_tsn = 0;
+    remote_init.initiate_tag = 12345;
+
+    // Generate a fresh local init for the association
+    let actual_local_init_bytes = generate_snap_token(&config).unwrap();
+    let local_init = ChunkInit::unmarshal(&actual_local_init_bytes).unwrap();
+    let remote_addr: SocketAddr = "192.168.1.1:5000".parse().unwrap();
+
+    let assoc = Association::new_with_out_of_band_init(
+        config.clone(),
+        1200,
+        remote_addr,
+        None,
+        local_init,
+        remote_init,
+    )
+    .expect("Should create out-of-band init association");
+
+    // peer_last_tsn should be u32::MAX when initial_tsn is 0
+    assert_eq!(
+        assoc.peer_last_tsn,
+        u32::MAX,
+        "peer_last_tsn should wrap to MAX when initial_tsn is 0"
+    );
+}
+
+#[test]
+fn test_out_of_band_rwnd_negotiation() {
+    let local_config = Arc::new(TransportConfig::default().with_max_receive_buffer_size(500_000));
+
+    let remote_config = TransportConfig::default().with_max_receive_buffer_size(300_000);
+
+    let local_init_bytes = generate_snap_token(&local_config).unwrap();
+    let remote_init_bytes = generate_snap_token(&remote_config).unwrap();
+
+    let local_init = ChunkInit::unmarshal(&local_init_bytes).unwrap();
+    let remote_init = ChunkInit::unmarshal(&remote_init_bytes).unwrap();
+
+    let remote_addr: SocketAddr = "192.168.1.1:5000".parse().unwrap();
+
+    let assoc = Association::new_with_out_of_band_init(
+        local_config.clone(),
+        1200,
+        remote_addr,
+        None,
+        local_init,
+        remote_init,
+    )
+    .expect("Should create out-of-band init association");
+
+    // rwnd should be set to remote's advertised receiver window credit
+    assert_eq!(
+        assoc.rwnd, 300_000,
+        "rwnd should be remote's advertised window"
+    );
 }

--- a/src/association/mod.rs
+++ b/src/association/mod.rs
@@ -19,7 +19,10 @@ use crate::chunk::chunk_shutdown::ChunkShutdown;
 use crate::chunk::chunk_shutdown_ack::ChunkShutdownAck;
 use crate::chunk::chunk_shutdown_complete::ChunkShutdownComplete;
 use crate::chunk::chunk_type::CT_FORWARD_TSN;
-use crate::config::{COMMON_HEADER_SIZE, DATA_CHUNK_HEADER_SIZE, ServerConfig, TransportConfig};
+use crate::config::COMMON_HEADER_SIZE;
+use crate::config::DATA_CHUNK_HEADER_SIZE;
+use crate::config::DEFAULT_SCTP_PORT;
+use crate::config::{ServerConfig, TransportConfig};
 use crate::error::{Error, Result};
 use crate::packet::{CommonHeader, Packet};
 use crate::param::Param;
@@ -44,6 +47,7 @@ use alloc::vec;
 use alloc::vec::Vec;
 use bytes::Bytes;
 use core::net::{IpAddr, SocketAddr};
+use core::num::NonZeroU32;
 use core::str::FromStr;
 use core::time::Duration;
 use log::{debug, error, trace, warn};
@@ -316,21 +320,15 @@ impl Default for Association {
 }
 
 impl Association {
-    pub(crate) fn new(
-        server_config: Option<Arc<ServerConfig>>,
+    fn new_common(
         config: Arc<TransportConfig>,
         max_payload_size: u32,
-        local_aid: AssociationId,
         remote_addr: SocketAddr,
         local_ip: Option<IpAddr>,
-        now: Instant,
+        side: Side,
+        verification_tag: u32,
+        initial_tsn: u32,
     ) -> Self {
-        let side = if server_config.is_some() {
-            Side::Server
-        } else {
-            Side::Client
-        };
-
         // It's a bit strange, but we're going backwards from the calculation in
         // config.rs to get max_payload_size from INITIAL_MTU.
         let mtu = max_payload_size + COMMON_HEADER_SIZE + DATA_CHUNK_HEADER_SIZE;
@@ -339,12 +337,8 @@ impl Association {
         // The initial cwnd before DATA transmission or after a sufficiently
         // long idle period MUST be set to min(4*MTU, max (2*MTU, 4380bytes)).
         let cwnd = (2 * mtu).clamp(4380, 4 * mtu);
-        let mut tsn = random::<u32>();
-        if tsn == 0 {
-            tsn += 1;
-        }
 
-        let mut this = Association {
+        Association {
             side,
             handshake_completed: false,
             max_receive_buffer_size: config.max_receive_buffer_size(),
@@ -370,16 +364,47 @@ impl Association {
             remote_addr,
             local_ip,
 
-            my_verification_tag: local_aid,
-            my_next_tsn: tsn,
-            my_next_rsn: tsn,
-            min_tsn2measure_rtt: tsn,
-            cumulative_tsn_ack_point: tsn - 1,
-            advanced_peer_tsn_ack_point: tsn - 1,
+            my_verification_tag: verification_tag,
+            my_next_tsn: initial_tsn,
+            my_next_rsn: initial_tsn,
+            min_tsn2measure_rtt: initial_tsn,
+            cumulative_tsn_ack_point: initial_tsn.wrapping_sub(1),
+            advanced_peer_tsn_ack_point: initial_tsn.wrapping_sub(1),
             error: None,
 
             ..Default::default()
+        }
+    }
+
+    pub(crate) fn new(
+        server_config: Option<Arc<ServerConfig>>,
+        config: Arc<TransportConfig>,
+        max_payload_size: u32,
+        local_aid: AssociationId,
+        remote_addr: SocketAddr,
+        local_ip: Option<IpAddr>,
+        now: Instant,
+    ) -> Self {
+        let side = if server_config.is_some() {
+            Side::Server
+        } else {
+            Side::Client
         };
+
+        let tsn = random::<NonZeroU32>().get();
+
+        let mut this = Self::new_common(
+            config,
+            max_payload_size,
+            remote_addr,
+            local_ip,
+            side,
+            local_aid,
+            tsn,
+        );
+
+        this.source_port = DEFAULT_SCTP_PORT;
+        this.destination_port = DEFAULT_SCTP_PORT;
 
         if side.is_client() {
             let mut init = ChunkInit {
@@ -400,6 +425,97 @@ impl Association {
         }
 
         this
+    }
+
+    /// Creates a new association using out-of-band exchanged SNAP tokens (INIT chunks).
+    ///
+    /// This allows skipping the SCTP 4-way handshake (RFC 4960 Section 5.1)
+    /// by exchanging tokens out-of-band (e.g., via a signaling channel
+    /// using SDP `a=sctp-init`). The association immediately transitions to
+    /// the ESTABLISHED state.
+    ///
+    /// **Note:** When using SNAP, **both** peers must call
+    /// [`Endpoint::connect`](crate::Endpoint::connect). There is no
+    /// server-side SNAP via [`Endpoint::handle`](crate::Endpoint::handle).
+    ///
+    /// See [draft-hancke-tsvwg-snap-01](https://datatracker.ietf.org/doc/draft-hancke-tsvwg-snap/).
+    ///
+    /// # Arguments
+    /// * `config` - Transport configuration.
+    /// * `max_payload_size` - Maximum payload size.
+    /// * `remote_addr` - Remote socket address.
+    /// * `local_ip` - Optional local IP address.
+    /// * `local_init` - Parsed local token (INIT chunk).
+    /// * `remote_init` - Parsed remote token (INIT chunk).
+    ///
+    /// # Returns
+    /// A new association in the ESTABLISHED state, or an error if the
+    /// tokens are invalid.
+    pub(crate) fn new_with_out_of_band_init(
+        config: Arc<TransportConfig>,
+        max_payload_size: u32,
+        remote_addr: SocketAddr,
+        local_ip: Option<IpAddr>,
+        local_init: ChunkInit,
+        remote_init: ChunkInit,
+    ) -> Result<Self> {
+        // Derive side deterministically: the peer with the lower initiate_tag
+        // acts as server so that log lines are distinguishable. This is purely
+        // cosmetic — equal tags are impossible because the caller in
+        // `connect_with_snap` rejects that case with `AidCollision`.
+        let side = if local_init.initiate_tag <= remote_init.initiate_tag {
+            Side::Server
+        } else {
+            Side::Client
+        };
+
+        // Use the TSN from our local INIT chunk
+        let tsn = local_init.initial_tsn;
+
+        let mut this = Self::new_common(
+            config.clone(),
+            max_payload_size,
+            remote_addr,
+            local_ip,
+            side,
+            local_init.initiate_tag,
+            tsn,
+        );
+
+        // Negotiate stream counts: use the smaller of our config limit and
+        // what the remote offers (RFC 4960 §5.1.1 cross-negotiation).
+        this.my_max_num_inbound_streams = core::cmp::min(
+            config.max_num_inbound_streams(),
+            remote_init.num_outbound_streams,
+        );
+        this.my_max_num_outbound_streams = core::cmp::min(
+            config.max_num_outbound_streams(),
+            remote_init.num_inbound_streams,
+        );
+
+        this.peer_verification_tag = remote_init.initiate_tag;
+
+        this.source_port = DEFAULT_SCTP_PORT;
+        this.destination_port = DEFAULT_SCTP_PORT;
+        this.handshake_completed = true;
+
+        this.apply_remote_init_params(
+            remote_init.initial_tsn,
+            remote_init.advertised_receiver_window_credit,
+            &remote_init.params,
+            "out-of-band init",
+        );
+
+        // Set state to ESTABLISHED - out-of-band init skips the handshake
+        this.set_state(AssociationState::Established);
+        this.events.push_back(Event::Connected);
+
+        debug!(
+            "[{}] out-of-band init association established: my_tag={:#x} peer_tag={:#x} tsn={}",
+            this.side, this.my_verification_tag, this.peer_verification_tag, this.my_next_tsn
+        );
+
+        Ok(this)
     }
 
     /// Returns application-facing event
@@ -806,13 +922,58 @@ impl Association {
         self.state
     }
 
+    /// Apply common remote-side parameters from an INIT or INIT-ACK chunk.
+    ///
+    /// Sets `peer_last_tsn`, `rwnd`, `ssthresh`, and `use_forward_tsn` based
+    /// on the remote peer's initial TSN, advertised window, and supported
+    /// extensions. Used by `handle_init`, `handle_init_ack`, and
+    /// `new_with_out_of_band_init`.
+    fn apply_remote_init_params(
+        &mut self,
+        initial_tsn: u32,
+        advertised_receiver_window_credit: u32,
+        params: &[Box<dyn Param + Send + Sync>],
+        context: &str,
+    ) {
+        // RFC 4960 §13.2: peer_last_tsn is the peer's initial TSN minus one.
+        self.peer_last_tsn = initial_tsn.wrapping_sub(1);
+
+        self.rwnd = advertised_receiver_window_credit;
+        debug!("[{}] initial rwnd={}", self.side, self.rwnd);
+
+        // RFC 4960 Sec 7.2.1
+        //  o  The initial value of ssthresh MAY be arbitrarily high (for
+        //     example, implementations MAY use the size of the receiver
+        //     advertised window).
+        self.ssthresh = self.rwnd;
+        trace!(
+            "[{}] updated cwnd={} ssthresh={} inflight={} ({})",
+            self.side,
+            self.cwnd,
+            self.ssthresh,
+            self.inflight_queue.get_num_bytes(),
+            context,
+        );
+
+        for param in params {
+            if let Some(v) = param.as_any().downcast_ref::<ParamSupportedExtensions>() {
+                for t in &v.chunk_types {
+                    if *t == CT_FORWARD_TSN {
+                        debug!("[{}] use ForwardTSN (on {})", self.side, context);
+                        self.use_forward_tsn = true;
+                    }
+                }
+            }
+        }
+        if !self.use_forward_tsn {
+            warn!("[{}] not using ForwardTSN (on {})", self.side, context);
+        }
+    }
+
     /// caller must hold self.lock
     fn send_init(&mut self) -> Result<()> {
         if let Some(stored_init) = &self.stored_init {
             debug!("[{}] sending INIT", self.side);
-
-            self.source_port = 5000; // Spec??
-            self.destination_port = 5000; // Spec??
 
             let outbound = Packet {
                 common_header: CommonHeader {
@@ -986,49 +1147,12 @@ impl Association {
         self.source_port = p.common_header.destination_port;
         self.destination_port = p.common_header.source_port;
 
-        // 13.2 This is the last TSN received in sequence.  This value
-        // is set initially by taking the peer's initial TSN,
-        // received in the INIT or INIT ACK chunk, and
-        // subtracting one from it.
-        self.peer_last_tsn = if i.initial_tsn == 0 {
-            u32::MAX
-        } else {
-            i.initial_tsn - 1
-        };
-
-        // Initialize rwnd from the peer's advertised receiver window credit.
-        // This mirrors what handle_init_ack does for the client side.
-        // Without this, rwnd stays at 0 (the default) until the first SACK
-        // is received, which blocks all DATA sending except zero-window probes.
-        self.rwnd = i.advertised_receiver_window_credit;
-        debug!("[{}] initial rwnd={}", self.side, self.rwnd);
-
-        // RFC 4960 Sec 7.2.1
-        //  o  The initial value of ssthresh MAY be arbitrarily high (for
-        //     example, implementations MAY use the size of the receiver
-        //     advertised window).
-        self.ssthresh = self.rwnd;
-        trace!(
-            "[{}] updated cwnd={} ssthresh={} inflight={} (INI)",
-            self.side,
-            self.cwnd,
-            self.ssthresh,
-            self.inflight_queue.get_num_bytes()
+        self.apply_remote_init_params(
+            i.initial_tsn,
+            i.advertised_receiver_window_credit,
+            &i.params,
+            "init",
         );
-
-        for param in &i.params {
-            if let Some(v) = param.as_any().downcast_ref::<ParamSupportedExtensions>() {
-                for t in &v.chunk_types {
-                    if *t == CT_FORWARD_TSN {
-                        debug!("[{}] use ForwardTSN (on init)", self.side);
-                        self.use_forward_tsn = true;
-                    }
-                }
-            }
-        }
-        if !self.use_forward_tsn {
-            warn!("[{}] not using ForwardTSN (on init)", self.side);
-        }
 
         let mut outbound = Packet {
             common_header: CommonHeader {
@@ -1087,11 +1211,6 @@ impl Association {
         self.my_max_num_outbound_streams =
             core::cmp::min(i.num_outbound_streams, self.my_max_num_outbound_streams);
         self.peer_verification_tag = i.initiate_tag;
-        self.peer_last_tsn = if i.initial_tsn == 0 {
-            u32::MAX
-        } else {
-            i.initial_tsn - 1
-        };
         if self.source_port != p.common_header.destination_port
             || self.destination_port != p.common_header.source_port
         {
@@ -1099,41 +1218,20 @@ impl Association {
             return Ok(vec![]);
         }
 
-        self.rwnd = i.advertised_receiver_window_credit;
-        debug!("[{}] initial rwnd={}", self.side, self.rwnd);
-
-        // RFC 4960 Sec 7.2.1
-        //  o  The initial value of ssthresh MAY be arbitrarily high (for
-        //     example, implementations MAY use the size of the receiver
-        //     advertised window).
-        self.ssthresh = self.rwnd;
-        trace!(
-            "[{}] updated cwnd={} ssthresh={} inflight={} (INI)",
-            self.side,
-            self.cwnd,
-            self.ssthresh,
-            self.inflight_queue.get_num_bytes()
+        self.apply_remote_init_params(
+            i.initial_tsn,
+            i.advertised_receiver_window_credit,
+            &i.params,
+            "initAck",
         );
 
         self.timers.stop(Timer::T1Init);
         self.stored_init = None;
 
-        let mut cookie_param = None;
-        for param in &i.params {
-            if let Some(v) = param.as_any().downcast_ref::<ParamStateCookie>() {
-                cookie_param = Some(v);
-            } else if let Some(v) = param.as_any().downcast_ref::<ParamSupportedExtensions>() {
-                for t in &v.chunk_types {
-                    if *t == CT_FORWARD_TSN {
-                        debug!("[{}] use ForwardTSN (on initAck)", self.side);
-                        self.use_forward_tsn = true;
-                    }
-                }
-            }
-        }
-        if !self.use_forward_tsn {
-            warn!("[{}] not using ForwardTSN (on initAck)", self.side);
-        }
+        let cookie_param = i
+            .params
+            .iter()
+            .find_map(|param| param.as_any().downcast_ref::<ParamStateCookie>());
 
         if let Some(v) = cookie_param {
             self.stored_cookie_echo = Some(ChunkCookieEcho {

--- a/src/config.rs
+++ b/src/config.rs
@@ -2,6 +2,7 @@ use crate::util::{AssociationIdGenerator, RandomAssociationIdGenerator};
 
 use alloc::boxed::Box;
 use alloc::sync::Arc;
+use bytes::Bytes;
 use core::fmt;
 
 /// MTU for inbound packet (from DTLS)
@@ -289,19 +290,50 @@ impl ServerConfig {
     }
 }
 
-/// Configuration for outgoing associations
+/// Default SCTP source/destination port (conventional for WebRTC data channels).
+pub const DEFAULT_SCTP_PORT: u16 = 5000;
+
+/// Maximum allowed size (in bytes) of a serialized SNAP token (INIT chunk)
+/// accepted via out-of-band negotiation. A typical token is well under
+/// 100 bytes; this limit prevents accidentally feeding megabytes of
+/// untrusted signaling data into the parser.
+pub const MAX_SNAP_INIT_BYTES: usize = 2048;
+
+/// Configuration for outgoing associations.
 ///
 /// Default values should be suitable for most internet applications.
 #[derive(Debug, Clone)]
 pub struct ClientConfig {
     /// Transport configuration to use
     pub transport: Arc<TransportConfig>,
+    /// Local SNAP token (INIT chunk) bytes.
+    ///
+    /// Generated via [`generate_snap_token`]. When both `local_sctp_init` and
+    /// `remote_sctp_init` are set, the association skips the SCTP 4-way
+    /// handshake (RFC 4960 Section 5.1) and immediately transitions to the
+    /// ESTABLISHED state.
+    ///
+    /// If only one side is set (e.g. the peer does not support SNAP), the
+    /// association falls back to the normal SCTP handshake.
+    ///
+    /// See [draft-hancke-tsvwg-snap-01](https://datatracker.ietf.org/doc/draft-hancke-tsvwg-snap/).
+    pub(crate) local_sctp_init: Option<Bytes>,
+    /// Remote SNAP token (INIT chunk) bytes.
+    ///
+    /// Received from the peer via a signaling channel (e.g., SDP `a=sctp-init`
+    /// attribute). Must be provided together with `local_sctp_init` to enable
+    /// SNAP.
+    ///
+    /// See [draft-hancke-tsvwg-snap-01](https://datatracker.ietf.org/doc/draft-hancke-tsvwg-snap/).
+    pub(crate) remote_sctp_init: Option<Bytes>,
 }
 
 impl Default for ClientConfig {
     fn default() -> Self {
         ClientConfig {
             transport: Arc::new(TransportConfig::default()),
+            local_sctp_init: None,
+            remote_sctp_init: None,
         }
     }
 }
@@ -311,4 +343,60 @@ impl ClientConfig {
     pub fn new() -> Self {
         ClientConfig::default()
     }
+
+    /// Enable SNAP (SCTP Negotiation Acceleration Protocol).
+    ///
+    /// Both a local and remote SNAP token (INIT chunk) must be provided.
+    /// The local token should be generated via [`generate_snap_token`] and
+    /// exchanged with the remote peer through a signaling channel (e.g.,
+    /// SDP `a=sctp-init` attribute). The remote token is the peer's
+    /// corresponding bytes received via signaling.
+    ///
+    /// When both are set, the association skips the SCTP 4-way handshake
+    /// (RFC 4960 Section 5.1) and immediately transitions to the ESTABLISHED
+    /// state.
+    ///
+    /// **Note:** When using SNAP, **both** peers must call
+    /// [`Endpoint::connect`](crate::Endpoint::connect) — there is no
+    /// server-side SNAP via [`Endpoint::handle`](crate::Endpoint::handle).
+    ///
+    /// See [draft-hancke-tsvwg-snap-01](https://datatracker.ietf.org/doc/draft-hancke-tsvwg-snap/).
+    pub fn with_snap(mut self, local_sctp_init: Bytes, remote_sctp_init: Bytes) -> Self {
+        self.local_sctp_init = Some(local_sctp_init);
+        self.remote_sctp_init = Some(remote_sctp_init);
+        self
+    }
+}
+
+/// Generate a SNAP token (INIT chunk) for out-of-band negotiation.
+///
+/// Creates a serialized SCTP INIT **chunk** (not a full SCTP packet — no
+/// common header or IP/UDP framing) with random `initiate_tag` and
+/// `initial_tsn` values, using the receiver window from the provided
+/// [`TransportConfig`]. Stream counts are set to `u16::MAX` so that the
+/// actual limit is determined by the peer's offer during negotiation.
+///
+/// The returned bytes are suitable for exchange via a signaling channel
+/// (e.g., SDP `a=sctp-init`) as described in
+/// [draft-hancke-tsvwg-snap-01](https://datatracker.ietf.org/doc/draft-hancke-tsvwg-snap/).
+///
+/// Each call generates fresh random values. The caller must hold onto the
+/// returned bytes and pass them to [`ClientConfig::with_snap`] alongside
+/// the remote peer's token.
+pub fn generate_snap_token(config: &TransportConfig) -> Result<Bytes, crate::error::Error> {
+    use crate::chunk::{Chunk, chunk_init::ChunkInit};
+    use core::num::NonZeroU32;
+    use rand::random;
+
+    let mut init = ChunkInit {
+        initiate_tag: random::<NonZeroU32>().get(),
+        initial_tsn: random::<NonZeroU32>().get(),
+        num_outbound_streams: u16::MAX,
+        num_inbound_streams: u16::MAX,
+        advertised_receiver_window_credit: config.max_receive_buffer_size(),
+        ..Default::default()
+    };
+    init.set_supported_extensions();
+    init.check()?;
+    init.marshal()
 }

--- a/src/endpoint/endpoint_test.rs
+++ b/src/endpoint/endpoint_test.rs
@@ -5,6 +5,7 @@ use std::println;
 
 use super::*;
 use crate::association::Event;
+use crate::config::generate_snap_token;
 use crate::error::{Error, Result};
 
 use crate::association::state::{AckMode, AssociationState};
@@ -34,6 +35,7 @@ use core::{cmp, mem};
 use log::{info, trace};
 use std::net::UdpSocket;
 use std::sync::{LazyLock, Mutex};
+use std::time::Instant;
 
 pub static SERVER_PORTS: LazyLock<Mutex<RangeFrom<u16>>> = LazyLock::new(|| Mutex::new(4433..));
 pub static CLIENT_PORTS: LazyLock<Mutex<RangeFrom<u16>>> = LazyLock::new(|| Mutex::new(44433..));
@@ -385,6 +387,7 @@ fn create_association_pair(
         } else {
             TransportConfig::default()
         }),
+        ..Default::default()
     });
     pair.client_conn_mut(client_ch).ack_mode = ack_mode;
     pair.server_conn_mut(server_ch).ack_mode = ack_mode;
@@ -2954,4 +2957,888 @@ fn test_assoc_reconfig_failure_clears_pending() -> Result<()> {
     );
 
     Ok(())
+}
+
+#[test]
+fn test_snap_connect_established_and_transmit_uses_peer_verification_tag() {
+    let now = Instant::now();
+
+    let local_transport = TransportConfig::default();
+    let remote_transport = TransportConfig::default();
+
+    let local_init_bytes = generate_snap_token(&local_transport).expect("generate local init");
+    let remote_init_bytes = generate_snap_token(&remote_transport).expect("generate remote init");
+
+    // Parse remote to check verification tag later
+    let remote_init =
+        ChunkInit::unmarshal(&remote_init_bytes).expect("unmarshal remote INIT chunk");
+
+    let mut endpoint = Endpoint::new(Arc::new(EndpointConfig::default()), None);
+    let remote_addr: SocketAddr = "127.0.0.1:5000".parse().unwrap();
+
+    let client_config = ClientConfig::new().with_snap(local_init_bytes, remote_init_bytes);
+    let (_ch, mut assoc) = endpoint
+        .connect(client_config, remote_addr)
+        .expect("SNAP connect should succeed");
+
+    assert_eq!(assoc.state(), AssociationState::Established);
+    assert_matches!(assoc.poll(), Some(Event::Connected));
+
+    // Ensure outbound packets use the peer's initiate_tag as the verification tag.
+    let mut stream = assoc
+        .open_stream(1, PayloadProtocolIdentifier::Binary)
+        .expect("open stream");
+    let msg = Bytes::from_static(b"hello");
+    stream
+        .write_sctp(&msg, PayloadProtocolIdentifier::Binary)
+        .expect("write_sctp");
+
+    let transmit = assoc
+        .poll_transmit(now)
+        .expect("expected at least one outbound datagram");
+    let Payload::RawEncode(datagrams) = transmit.payload else {
+        panic!("expected RawEncode transmit");
+    };
+    assert!(
+        !datagrams.is_empty(),
+        "expected at least one outbound packet"
+    );
+
+    let pkt = Packet::unmarshal(&datagrams[0]).expect("unmarshal outbound packet");
+    assert_eq!(
+        pkt.common_header.verification_tag, remote_init.initiate_tag,
+        "outbound packet should use peer initiate_tag as verification_tag"
+    );
+}
+
+#[test]
+fn test_server_retransmitted_init_routes_to_existing_association() {
+    let now = Instant::now();
+
+    let mut endpoint = Endpoint::new(
+        Arc::new(EndpointConfig::default()),
+        Some(Arc::new(ServerConfig::default())),
+    );
+
+    let remote: SocketAddr = "127.0.0.1:5000".parse().unwrap();
+    let init_tag: u32 = 0x1122_3344;
+
+    let init = ChunkInit {
+        is_ack: false,
+        initiate_tag: init_tag,
+        ..Default::default()
+    };
+
+    let pkt = Packet {
+        common_header: CommonHeader {
+            source_port: 5000,
+            destination_port: 5000,
+            verification_tag: 0,
+        },
+        chunks: vec![Box::new(init)],
+    };
+
+    let bytes = pkt.marshal().expect("marshal INIT packet");
+
+    let (ch1, ev1) = endpoint
+        .handle(now, remote, None, None, bytes.clone())
+        .expect("first INIT should be handled");
+    assert!(
+        matches!(ev1, DatagramEvent::NewAssociation(_)),
+        "first INIT should create a new association"
+    );
+
+    // Same INIT retransmitted: should route to the same association handle.
+    let (ch2, ev2) = endpoint
+        .handle(now, remote, None, None, bytes)
+        .expect("retransmitted INIT should be handled");
+    assert_eq!(
+        ch2, ch1,
+        "retransmitted INIT should map to same association"
+    );
+    assert!(
+        matches!(ev2, DatagramEvent::AssociationEvent(_)),
+        "retransmitted INIT should be routed to existing association"
+    );
+}
+
+#[test]
+fn test_snap_rejects_invalid_remote_bytes() {
+    let mut endpoint = Endpoint::new(Arc::new(EndpointConfig::default()), None);
+    let remote_addr: SocketAddr = "127.0.0.1:5000".parse().unwrap();
+
+    let local_init = generate_snap_token(&TransportConfig::default()).expect("local init");
+    let client_config = ClientConfig::new().with_snap(local_init, Bytes::from_static(b"nope"));
+    let res = endpoint.connect(client_config, remote_addr);
+    assert!(
+        matches!(
+            res,
+            Err(ConnectError::Snap(SnapError::ParseFailed {
+                side: SnapSide::Remote,
+                ..
+            }))
+        ),
+        "invalid remote bytes should fail with ParseFailed"
+    );
+}
+
+#[test]
+fn test_snap_rejects_invalid_local_bytes() {
+    let mut endpoint = Endpoint::new(Arc::new(EndpointConfig::default()), None);
+    let remote_addr: SocketAddr = "127.0.0.1:5000".parse().unwrap();
+
+    let remote_init = generate_snap_token(&TransportConfig::default()).expect("remote init");
+    let client_config = ClientConfig::new().with_snap(Bytes::from_static(b"nope"), remote_init);
+    let res = endpoint.connect(client_config, remote_addr);
+    assert!(
+        matches!(
+            res,
+            Err(ConnectError::Snap(SnapError::ParseFailed {
+                side: SnapSide::Local,
+                ..
+            }))
+        ),
+        "invalid local bytes should fail with ParseFailed"
+    );
+}
+
+#[test]
+fn test_snap_rejects_remote_init_ack() {
+    let mut endpoint = Endpoint::new(Arc::new(EndpointConfig::default()), None);
+    let remote_addr: SocketAddr = "127.0.0.1:5000".parse().unwrap();
+
+    let local_init = generate_snap_token(&TransportConfig::default()).expect("local init");
+    let remote_init_ack = ChunkInit {
+        is_ack: true,
+        initiate_tag: 1,
+        ..Default::default()
+    };
+    let remote_bytes = remote_init_ack.marshal().expect("marshal remote INIT-ACK");
+
+    let client_config = ClientConfig::new().with_snap(local_init, remote_bytes);
+    let res = endpoint.connect(client_config, remote_addr);
+    assert!(
+        matches!(
+            res,
+            Err(ConnectError::Snap(SnapError::InvalidInitAck {
+                side: SnapSide::Remote
+            }))
+        ),
+        "remote INIT-ACK should be rejected"
+    );
+}
+
+#[test]
+fn test_snap_rejects_remote_init_with_zero_initiate_tag() {
+    let mut endpoint = Endpoint::new(Arc::new(EndpointConfig::default()), None);
+    let remote_addr: SocketAddr = "127.0.0.1:5000".parse().unwrap();
+
+    let local_init = generate_snap_token(&TransportConfig::default()).expect("local init");
+    let remote_init = ChunkInit {
+        is_ack: false,
+        initiate_tag: 0,
+        ..Default::default()
+    };
+    let remote_bytes = remote_init.marshal().expect("marshal remote INIT");
+
+    let client_config = ClientConfig::new().with_snap(local_init, remote_bytes);
+    let res = endpoint.connect(client_config, remote_addr);
+    assert!(
+        matches!(
+            res,
+            Err(ConnectError::Snap(SnapError::ZeroInitiateTag {
+                side: SnapSide::Remote
+            }))
+        ),
+        "remote INIT with initiate_tag=0 should be rejected"
+    );
+}
+
+#[test]
+fn test_snap_partial_config_falls_back_to_handshake() {
+    let mut endpoint = Endpoint::new(Arc::new(EndpointConfig::default()), None);
+    let remote_addr: SocketAddr = "127.0.0.1:5000".parse().unwrap();
+
+    // Only local_sctp_init set, remote missing — should fall back to normal handshake
+    let local_init = generate_snap_token(&TransportConfig::default()).expect("local init");
+    let client_config = ClientConfig {
+        local_sctp_init: Some(local_init),
+        ..Default::default()
+    };
+    let (_ch, assoc) = endpoint
+        .connect(client_config, remote_addr)
+        .expect("partial SNAP config should fall back to handshake");
+    assert_eq!(
+        assoc.state(),
+        AssociationState::CookieWait,
+        "should use normal handshake when only local init provided"
+    );
+
+    // Only remote_sctp_init set, local missing — should fall back to normal handshake
+    let remote_init = generate_snap_token(&TransportConfig::default()).expect("remote init");
+    let client_config = ClientConfig {
+        remote_sctp_init: Some(remote_init),
+        ..Default::default()
+    };
+    let (_ch, assoc) = endpoint
+        .connect(client_config, remote_addr)
+        .expect("partial SNAP config should fall back to handshake");
+    assert_eq!(
+        assoc.state(),
+        AssociationState::CookieWait,
+        "should use normal handshake when only remote init provided"
+    );
+}
+
+#[test]
+fn test_snap_rejects_reused_local_init() {
+    let mut endpoint = Endpoint::new(Arc::new(EndpointConfig::default()), None);
+    let remote_addr: SocketAddr = "127.0.0.1:5000".parse().unwrap();
+
+    // Generate a single local init — reusing it causes a collision
+    let local_init = generate_snap_token(&TransportConfig::default()).expect("local init");
+
+    let remote1 = generate_snap_token(&TransportConfig::default()).expect("remote init 1");
+    let remote2 = generate_snap_token(&TransportConfig::default()).expect("remote init 2");
+
+    // First connect succeeds
+    let cfg1 = ClientConfig::new().with_snap(local_init.clone(), remote1);
+    let res1 = endpoint.connect(cfg1, remote_addr);
+    assert!(res1.is_ok(), "first SNAP connect should succeed");
+
+    // Second connect with same local_init collides on local_aid
+    let cfg2 = ClientConfig::new().with_snap(local_init, remote2);
+    let res2 = endpoint.connect(cfg2, remote_addr);
+    assert!(
+        matches!(
+            res2,
+            Err(ConnectError::Snap(SnapError::AidCollision { .. }))
+        ),
+        "second SNAP connect should fail due to AID collision"
+    );
+}
+
+#[test]
+fn test_snap_rejects_local_init_ack() {
+    let mut endpoint = Endpoint::new(Arc::new(EndpointConfig::default()), None);
+    let remote_addr: SocketAddr = "127.0.0.1:5000".parse().unwrap();
+
+    let remote_init = generate_snap_token(&TransportConfig::default()).expect("remote init");
+    let local_init_ack = ChunkInit {
+        is_ack: true,
+        initiate_tag: 1,
+        ..Default::default()
+    };
+    let local_bytes = local_init_ack.marshal().expect("marshal local INIT-ACK");
+
+    let client_config = ClientConfig::new().with_snap(local_bytes, remote_init);
+    let res = endpoint.connect(client_config, remote_addr);
+    assert!(
+        matches!(
+            res,
+            Err(ConnectError::Snap(SnapError::InvalidInitAck {
+                side: SnapSide::Local
+            }))
+        ),
+        "local INIT-ACK should be rejected"
+    );
+}
+
+#[test]
+fn test_snap_rejects_local_init_with_zero_initiate_tag() {
+    let mut endpoint = Endpoint::new(Arc::new(EndpointConfig::default()), None);
+    let remote_addr: SocketAddr = "127.0.0.1:5000".parse().unwrap();
+
+    let remote_init = generate_snap_token(&TransportConfig::default()).expect("remote init");
+    let local_init = ChunkInit {
+        is_ack: false,
+        initiate_tag: 0,
+        ..Default::default()
+    };
+    let local_bytes = local_init.marshal().expect("marshal local INIT");
+
+    let client_config = ClientConfig::new().with_snap(local_bytes, remote_init);
+    let res = endpoint.connect(client_config, remote_addr);
+    assert!(
+        matches!(
+            res,
+            Err(ConnectError::Snap(SnapError::ZeroInitiateTag {
+                side: SnapSide::Local
+            }))
+        ),
+        "local INIT with initiate_tag=0 should be rejected"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// SNAP hardening tests: size limits, truncated / empty / oversized input,
+// wrong chunk types, RFC field validation, round-trip token consistency.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_snap_rejects_empty_bytes() {
+    let mut endpoint = Endpoint::new(Arc::new(EndpointConfig::default()), None);
+    let remote_addr: SocketAddr = "127.0.0.1:5000".parse().unwrap();
+
+    let valid = generate_snap_token(&TransportConfig::default()).expect("valid init");
+
+    // Empty remote
+    let cfg = ClientConfig::new().with_snap(valid.clone(), Bytes::new());
+    let res = endpoint.connect(cfg, remote_addr);
+    assert!(
+        matches!(
+            res,
+            Err(ConnectError::Snap(SnapError::ParseFailed {
+                side: SnapSide::Remote,
+                ..
+            }))
+        ),
+        "empty remote bytes should fail parsing"
+    );
+
+    // Empty local
+    let cfg = ClientConfig::new().with_snap(Bytes::new(), valid);
+    let res = endpoint.connect(cfg, remote_addr);
+    assert!(
+        matches!(
+            res,
+            Err(ConnectError::Snap(SnapError::ParseFailed {
+                side: SnapSide::Local,
+                ..
+            }))
+        ),
+        "empty local bytes should fail parsing"
+    );
+}
+
+#[test]
+fn test_snap_rejects_truncated_bytes() {
+    let mut endpoint = Endpoint::new(Arc::new(EndpointConfig::default()), None);
+    let remote_addr: SocketAddr = "127.0.0.1:5000".parse().unwrap();
+
+    let valid = generate_snap_token(&TransportConfig::default()).expect("valid init");
+
+    // Truncate to just 10 bytes — not enough for INIT header + fixed fields
+    let truncated = valid.slice(..10.min(valid.len()));
+
+    let cfg = ClientConfig::new().with_snap(valid.clone(), truncated.clone());
+    let res = endpoint.connect(cfg, remote_addr);
+    assert!(
+        matches!(
+            res,
+            Err(ConnectError::Snap(SnapError::ParseFailed {
+                side: SnapSide::Remote,
+                ..
+            }))
+        ),
+        "truncated remote bytes should fail parsing"
+    );
+
+    let cfg = ClientConfig::new().with_snap(truncated, valid);
+    let res = endpoint.connect(cfg, remote_addr);
+    assert!(
+        matches!(
+            res,
+            Err(ConnectError::Snap(SnapError::ParseFailed {
+                side: SnapSide::Local,
+                ..
+            }))
+        ),
+        "truncated local bytes should fail parsing"
+    );
+}
+
+#[test]
+fn test_snap_rejects_oversized_bytes() {
+    use crate::config::MAX_SNAP_INIT_BYTES;
+
+    let mut endpoint = Endpoint::new(Arc::new(EndpointConfig::default()), None);
+    let remote_addr: SocketAddr = "127.0.0.1:5000".parse().unwrap();
+
+    let valid = generate_snap_token(&TransportConfig::default()).expect("valid init");
+    let oversized = Bytes::from(vec![0u8; MAX_SNAP_INIT_BYTES + 1]);
+
+    // Oversized remote
+    let cfg = ClientConfig::new().with_snap(valid.clone(), oversized.clone());
+    let res = endpoint.connect(cfg, remote_addr);
+    assert!(
+        matches!(
+            res,
+            Err(ConnectError::Snap(SnapError::OversizedInit {
+                side: SnapSide::Remote,
+                ..
+            }))
+        ),
+        "oversized remote bytes should be rejected"
+    );
+
+    // Oversized local
+    let cfg = ClientConfig::new().with_snap(oversized, valid);
+    let res = endpoint.connect(cfg, remote_addr);
+    assert!(
+        matches!(
+            res,
+            Err(ConnectError::Snap(SnapError::OversizedInit {
+                side: SnapSide::Local,
+                ..
+            }))
+        ),
+        "oversized local bytes should be rejected"
+    );
+}
+
+#[test]
+fn test_snap_rejects_remote_init_zero_inbound_streams() {
+    let mut endpoint = Endpoint::new(Arc::new(EndpointConfig::default()), None);
+    let remote_addr: SocketAddr = "127.0.0.1:5000".parse().unwrap();
+
+    let local_init = generate_snap_token(&TransportConfig::default()).expect("local init");
+    let bad_remote = ChunkInit {
+        is_ack: false,
+        initiate_tag: 0xDEAD_BEEF,
+        initial_tsn: 1,
+        num_outbound_streams: 1,
+        num_inbound_streams: 0, // RFC violation
+        advertised_receiver_window_credit: 65535,
+        ..Default::default()
+    };
+    let remote_bytes = bad_remote.marshal().expect("marshal bad remote INIT");
+
+    let cfg = ClientConfig::new().with_snap(local_init, remote_bytes);
+    let res = endpoint.connect(cfg, remote_addr);
+    assert!(
+        matches!(
+            res,
+            Err(ConnectError::Snap(SnapError::InvalidInit {
+                side: SnapSide::Remote,
+                ..
+            }))
+        ),
+        "remote INIT with num_inbound_streams=0 should be rejected: got {:?}",
+        res
+    );
+}
+
+#[test]
+fn test_snap_rejects_remote_init_zero_outbound_streams() {
+    let mut endpoint = Endpoint::new(Arc::new(EndpointConfig::default()), None);
+    let remote_addr: SocketAddr = "127.0.0.1:5000".parse().unwrap();
+
+    let local_init = generate_snap_token(&TransportConfig::default()).expect("local init");
+    let bad_remote = ChunkInit {
+        is_ack: false,
+        initiate_tag: 0xDEAD_BEEF,
+        initial_tsn: 1,
+        num_outbound_streams: 0, // RFC violation
+        num_inbound_streams: 1,
+        advertised_receiver_window_credit: 65535,
+        ..Default::default()
+    };
+    let remote_bytes = bad_remote.marshal().expect("marshal bad remote INIT");
+
+    let cfg = ClientConfig::new().with_snap(local_init, remote_bytes);
+    let res = endpoint.connect(cfg, remote_addr);
+    assert!(
+        matches!(
+            res,
+            Err(ConnectError::Snap(SnapError::InvalidInit {
+                side: SnapSide::Remote,
+                ..
+            }))
+        ),
+        "remote INIT with num_outbound_streams=0 should be rejected: got {:?}",
+        res
+    );
+}
+
+#[test]
+fn test_snap_rejects_remote_init_small_arwnd() {
+    let mut endpoint = Endpoint::new(Arc::new(EndpointConfig::default()), None);
+    let remote_addr: SocketAddr = "127.0.0.1:5000".parse().unwrap();
+
+    let local_init = generate_snap_token(&TransportConfig::default()).expect("local init");
+    let bad_remote = ChunkInit {
+        is_ack: false,
+        initiate_tag: 0xDEAD_BEEF,
+        initial_tsn: 1,
+        num_outbound_streams: 1,
+        num_inbound_streams: 1,
+        advertised_receiver_window_credit: 100, // RFC says >= 1500
+        ..Default::default()
+    };
+    let remote_bytes = bad_remote.marshal().expect("marshal bad remote INIT");
+
+    let cfg = ClientConfig::new().with_snap(local_init, remote_bytes);
+    let res = endpoint.connect(cfg, remote_addr);
+    assert!(
+        matches!(
+            res,
+            Err(ConnectError::Snap(SnapError::InvalidInit {
+                side: SnapSide::Remote,
+                ..
+            }))
+        ),
+        "remote INIT with a_rwnd < 1500 should be rejected: got {:?}",
+        res
+    );
+}
+
+#[test]
+fn test_snap_rejects_local_init_zero_inbound_streams() {
+    let mut endpoint = Endpoint::new(Arc::new(EndpointConfig::default()), None);
+    let remote_addr: SocketAddr = "127.0.0.1:5000".parse().unwrap();
+
+    let remote_init = generate_snap_token(&TransportConfig::default()).expect("remote init");
+    let bad_local = ChunkInit {
+        is_ack: false,
+        initiate_tag: 0xCAFE_BABE,
+        initial_tsn: 1,
+        num_outbound_streams: 1,
+        num_inbound_streams: 0,
+        advertised_receiver_window_credit: 65535,
+        ..Default::default()
+    };
+    let local_bytes = bad_local.marshal().expect("marshal bad local INIT");
+
+    let cfg = ClientConfig::new().with_snap(local_bytes, remote_init);
+    let res = endpoint.connect(cfg, remote_addr);
+    assert!(
+        matches!(
+            res,
+            Err(ConnectError::Snap(SnapError::InvalidInit {
+                side: SnapSide::Local,
+                ..
+            }))
+        ),
+        "local INIT with num_inbound_streams=0 should be rejected: got {:?}",
+        res
+    );
+}
+
+#[test]
+fn test_snap_rejects_local_init_small_arwnd() {
+    let mut endpoint = Endpoint::new(Arc::new(EndpointConfig::default()), None);
+    let remote_addr: SocketAddr = "127.0.0.1:5000".parse().unwrap();
+
+    let remote_init = generate_snap_token(&TransportConfig::default()).expect("remote init");
+    let bad_local = ChunkInit {
+        is_ack: false,
+        initiate_tag: 0xCAFE_BABE,
+        initial_tsn: 1,
+        num_outbound_streams: 1,
+        num_inbound_streams: 1,
+        advertised_receiver_window_credit: 0,
+        ..Default::default()
+    };
+    let local_bytes = bad_local.marshal().expect("marshal bad local INIT");
+
+    let cfg = ClientConfig::new().with_snap(local_bytes, remote_init);
+    let res = endpoint.connect(cfg, remote_addr);
+    assert!(
+        matches!(
+            res,
+            Err(ConnectError::Snap(SnapError::InvalidInit {
+                side: SnapSide::Local,
+                ..
+            }))
+        ),
+        "local INIT with a_rwnd=0 should be rejected: got {:?}",
+        res
+    );
+}
+
+#[test]
+fn test_snap_generate_token_roundtrip_is_valid() {
+    let config = TransportConfig::default();
+    let bytes = generate_snap_token(&config).expect("generate token");
+
+    assert!(
+        bytes.len() <= crate::config::MAX_SNAP_INIT_BYTES,
+        "generated token should be within MAX_SNAP_INIT_BYTES"
+    );
+
+    let init = ChunkInit::unmarshal(&bytes).expect("unmarshal generated token");
+    assert!(!init.is_ack, "generated token should be INIT, not INIT-ACK");
+    assert_ne!(init.initiate_tag, 0, "initiate_tag must not be zero");
+    assert_ne!(init.initial_tsn, 0, "initial_tsn must not be zero");
+    assert_eq!(init.num_outbound_streams, u16::MAX);
+    assert_eq!(init.num_inbound_streams, u16::MAX);
+    assert_eq!(
+        init.advertised_receiver_window_credit,
+        config.max_receive_buffer_size()
+    );
+
+    // check() should pass for a token we generated ourselves
+    init.check()
+        .expect("check() should pass on generated token");
+}
+
+#[test]
+fn test_snap_generate_token_unique_per_call() {
+    let config = TransportConfig::default();
+    let t1 = generate_snap_token(&config).expect("token 1");
+    let t2 = generate_snap_token(&config).expect("token 2");
+    assert_ne!(t1, t2, "two generated tokens should differ (random values)");
+
+    let i1 = ChunkInit::unmarshal(&t1).expect("parse t1");
+    let i2 = ChunkInit::unmarshal(&t2).expect("parse t2");
+    assert_ne!(
+        i1.initiate_tag, i2.initiate_tag,
+        "initiate_tags should differ"
+    );
+}
+
+#[test]
+fn test_snap_rejects_wrong_chunk_type_bytes() {
+    use crate::chunk::Chunk;
+    use crate::chunk::chunk_selective_ack::ChunkSelectiveAck;
+
+    let mut endpoint = Endpoint::new(Arc::new(EndpointConfig::default()), None);
+    let remote_addr: SocketAddr = "127.0.0.1:5000".parse().unwrap();
+
+    let valid = generate_snap_token(&TransportConfig::default()).expect("valid init");
+
+    // Build a SACK chunk and try to use it as a SNAP INIT
+    let sack = ChunkSelectiveAck {
+        cumulative_tsn_ack: 1,
+        advertised_receiver_window_credit: 65535,
+        gap_ack_blocks: vec![],
+        duplicate_tsn: vec![],
+    };
+    let sack_bytes = sack.marshal().expect("marshal SACK");
+
+    let cfg = ClientConfig::new().with_snap(valid, sack_bytes);
+    let res = endpoint.connect(cfg, remote_addr);
+    assert!(
+        matches!(
+            res,
+            Err(ConnectError::Snap(SnapError::ParseFailed {
+                side: SnapSide::Remote,
+                ..
+            }))
+        ),
+        "SACK bytes should fail to parse as INIT: got {:?}",
+        res
+    );
+}
+
+#[test]
+fn test_snap_rejects_both_sides_empty() {
+    let mut endpoint = Endpoint::new(Arc::new(EndpointConfig::default()), None);
+    let remote_addr: SocketAddr = "127.0.0.1:5000".parse().unwrap();
+
+    let cfg = ClientConfig::new().with_snap(Bytes::new(), Bytes::new());
+    let res = endpoint.connect(cfg, remote_addr);
+    assert!(
+        matches!(res, Err(ConnectError::Snap(SnapError::ParseFailed { .. }))),
+        "two empty byte slices should fail"
+    );
+}
+
+#[test]
+fn test_snap_rejects_random_garbage_bytes() {
+    let mut endpoint = Endpoint::new(Arc::new(EndpointConfig::default()), None);
+    let remote_addr: SocketAddr = "127.0.0.1:5000".parse().unwrap();
+
+    let valid = generate_snap_token(&TransportConfig::default()).expect("valid init");
+
+    // 50 bytes of pseudo-random garbage
+    let garbage = Bytes::from(vec![0xAB; 50]);
+
+    let cfg = ClientConfig::new().with_snap(valid.clone(), garbage.clone());
+    let res = endpoint.connect(cfg, remote_addr);
+    assert!(
+        matches!(
+            res,
+            Err(ConnectError::Snap(SnapError::ParseFailed {
+                side: SnapSide::Remote,
+                ..
+            }))
+        ),
+        "garbage remote bytes should fail: got {:?}",
+        res
+    );
+
+    let cfg = ClientConfig::new().with_snap(garbage, valid);
+    let res = endpoint.connect(cfg, remote_addr);
+    assert!(
+        matches!(
+            res,
+            Err(ConnectError::Snap(SnapError::ParseFailed {
+                side: SnapSide::Local,
+                ..
+            }))
+        ),
+        "garbage local bytes should fail: got {:?}",
+        res
+    );
+}
+
+#[test]
+fn test_snap_identical_local_and_remote_init() {
+    let mut endpoint = Endpoint::new(Arc::new(EndpointConfig::default()), None);
+    let remote_addr: SocketAddr = "127.0.0.1:5000".parse().unwrap();
+
+    let token = generate_snap_token(&TransportConfig::default()).expect("token");
+
+    let cfg = ClientConfig::new().with_snap(token.clone(), token);
+    let res = endpoint.connect(cfg, remote_addr);
+    assert!(
+        matches!(res, Err(ConnectError::Snap(SnapError::AidCollision { .. }))),
+        "same token for both sides should collide: got {:?}",
+        res
+    );
+}
+
+#[test]
+fn test_snap_end_to_end_bidirectional_data() {
+    // Two endpoints, both using Endpoint::connect with SNAP, exchanging data
+    // through the full Endpoint::handle pipeline.
+    let endpoint_config = Arc::new(EndpointConfig::default());
+    let transport = TransportConfig::default();
+
+    let init_a = generate_snap_token(&transport).expect("init A");
+    let init_b = generate_snap_token(&transport).expect("init B");
+
+    let addr_a: SocketAddr = SocketAddr::new(
+        Ipv6Addr::LOCALHOST.into(),
+        CLIENT_PORTS.lock().unwrap().next().unwrap(),
+    );
+    let addr_b: SocketAddr = SocketAddr::new(
+        Ipv6Addr::LOCALHOST.into(),
+        CLIENT_PORTS.lock().unwrap().next().unwrap(),
+    );
+
+    // Both sides are clients (no server config) — this is the SNAP model.
+    let mut ep_a = Endpoint::new(endpoint_config.clone(), None);
+    let mut ep_b = Endpoint::new(endpoint_config, None);
+
+    let cfg_a = ClientConfig::new().with_snap(init_a.clone(), init_b.clone());
+    let (ch_a, mut assoc_a) = ep_a.connect(cfg_a, addr_b).expect("SNAP connect A");
+
+    let cfg_b = ClientConfig::new().with_snap(init_b, init_a);
+    let (ch_b, mut assoc_b) = ep_b.connect(cfg_b, addr_a).expect("SNAP connect B");
+
+    // Both should be established immediately.
+    assert_eq!(assoc_a.state(), AssociationState::Established);
+    assert_eq!(assoc_b.state(), AssociationState::Established);
+    assert_matches!(assoc_a.poll(), Some(Event::Connected));
+    assert_matches!(assoc_b.poll(), Some(Event::Connected));
+
+    let now = Instant::now();
+
+    // A writes to B.
+    let si = 1u16;
+    let msg_a = Bytes::from_static(b"hello from A");
+    let mut stream_a = assoc_a
+        .open_stream(si, PayloadProtocolIdentifier::Binary)
+        .expect("open stream A");
+    stream_a
+        .write_sctp(&msg_a, PayloadProtocolIdentifier::Binary)
+        .expect("write A");
+
+    // Pump transmits from A into B via Endpoint::handle.
+    while let Some(transmit) = assoc_a.poll_transmit(now) {
+        if let Payload::RawEncode(datagrams) = transmit.payload {
+            for dgram in datagrams {
+                if let Some((handle, event)) = ep_b.handle(now, addr_a, None, None, dgram) {
+                    assert_eq!(handle, ch_b);
+                    if let DatagramEvent::AssociationEvent(ev) = event {
+                        assoc_b.handle_event(ev);
+                    }
+                }
+            }
+        }
+    }
+
+    // B should now have data.
+    let accepted = assoc_b.accept_stream().expect("accept stream on B");
+    assert_eq!(accepted.stream_identifier, si);
+
+    let mut buf = vec![0u8; 64];
+    let chunks = assoc_b
+        .stream(si)
+        .expect("get stream B")
+        .read_sctp()
+        .expect("read B")
+        .expect("expected data");
+    let n = chunks.read(&mut buf).expect("read payload");
+    assert_eq!(&buf[..n], b"hello from A");
+
+    // B writes back to A.
+    let msg_b = Bytes::from_static(b"hello from B");
+    assoc_b
+        .stream(si)
+        .expect("get stream B for write")
+        .write_sctp(&msg_b, PayloadProtocolIdentifier::Binary)
+        .expect("write B");
+
+    // Pump transmits from B into A.
+    while let Some(transmit) = assoc_b.poll_transmit(now) {
+        if let Payload::RawEncode(datagrams) = transmit.payload {
+            for dgram in datagrams {
+                if let Some((handle, event)) = ep_a.handle(now, addr_b, None, None, dgram) {
+                    assert_eq!(handle, ch_a);
+                    if let DatagramEvent::AssociationEvent(ev) = event {
+                        assoc_a.handle_event(ev);
+                    }
+                }
+            }
+        }
+    }
+
+    // A should now have data back from B.
+    let chunks = assoc_a
+        .stream(si)
+        .expect("get stream A")
+        .read_sctp()
+        .expect("read A")
+        .expect("expected data from B");
+    let n = chunks.read(&mut buf).expect("read payload from B");
+    assert_eq!(&buf[..n], b"hello from B");
+}
+
+#[test]
+fn test_snap_association_drains_cleanly() {
+    // Verify that a SNAP association, once drained, properly cleans up both
+    // association_ids and association_ids_init in the endpoint.
+    let mut endpoint = Endpoint::new(Arc::new(EndpointConfig::default()), None);
+    let remote_addr: SocketAddr = "127.0.0.1:5000".parse().unwrap();
+
+    let local_init = generate_snap_token(&TransportConfig::default()).expect("local init");
+    let remote_init = generate_snap_token(&TransportConfig::default()).expect("remote init");
+
+    let local_tag = ChunkInit::unmarshal(&local_init)
+        .expect("parse local")
+        .initiate_tag;
+    let remote_tag = ChunkInit::unmarshal(&remote_init)
+        .expect("parse remote")
+        .initiate_tag;
+
+    let cfg = ClientConfig::new().with_snap(local_init, remote_init);
+    let (ch, _assoc) = endpoint.connect(cfg, remote_addr).expect("SNAP connect");
+
+    // Endpoint should have entries in both routing tables.
+    assert!(
+        endpoint.association_ids.contains_key(&local_tag),
+        "local_tag should be in association_ids"
+    );
+    assert!(
+        endpoint.association_ids_init.contains_key(&remote_tag),
+        "remote_tag should be in association_ids_init"
+    );
+
+    // Simulate draining: send the Drained endpoint event.
+    let drain_event = EndpointEvent(EndpointEventInner::Drained);
+    endpoint.handle_event(ch, drain_event);
+
+    // Both routing tables should be cleaned up.
+    assert!(
+        !endpoint.association_ids.contains_key(&local_tag),
+        "local_tag should be removed from association_ids after drain"
+    );
+    assert!(
+        !endpoint.association_ids_init.contains_key(&remote_tag),
+        "remote_tag should be removed from association_ids_init after drain"
+    );
 }

--- a/src/endpoint/mod.rs
+++ b/src/endpoint/mod.rs
@@ -3,7 +3,7 @@ mod endpoint_test;
 
 use alloc::boxed::Box;
 use alloc::collections::VecDeque;
-use alloc::string::String;
+use alloc::string::{String, ToString};
 use alloc::sync::Arc;
 use core::fmt;
 use core::iter;
@@ -12,8 +12,8 @@ use core::ops::{Index, IndexMut};
 use std::collections::HashMap;
 use std::time::Instant;
 
-use crate::association::Association;
-use crate::chunk::chunk_type::CT_INIT;
+use crate::chunk::{chunk_init::ChunkInit, chunk_type::CT_INIT};
+use crate::config::MAX_SNAP_INIT_BYTES;
 use crate::config::{ClientConfig, EndpointConfig, ServerConfig, TransportConfig};
 use crate::packet::PartialDecode;
 use crate::shared::AssociationEvent;
@@ -21,9 +21,10 @@ use crate::shared::{AssociationEventInner, AssociationId};
 use crate::shared::{EndpointEvent, EndpointEventInner};
 use crate::util::{AssociationIdGenerator, RandomAssociationIdGenerator};
 use crate::{EcnCodepoint, Payload, Transmit};
+use crate::{association::Association, chunk::Chunk};
 
 use bytes::Bytes;
-use log::{debug, trace};
+use log::{debug, trace, warn};
 use rand::{SeedableRng, rngs::StdRng};
 use rustc_hash::FxHashMap;
 use slab::Slab;
@@ -152,7 +153,7 @@ impl Endpoint {
             //TODO: improve INIT handling for DoS attack
             if partial_decode.first_chunk_type == CT_INIT {
                 if let Some(dst_cid) = partial_decode.initiate_tag {
-                    self.association_ids.get(&dst_cid).cloned()
+                    self.association_ids_init.get(&dst_cid).cloned()
                 } else {
                     None
                 }
@@ -183,7 +184,26 @@ impl Endpoint {
             .map(|(ch, a)| (ch, DatagramEvent::NewAssociation(a)))
     }
 
-    /// Initiate an Association
+    /// Initiate an association.
+    ///
+    /// If SNAP tokens (INIT chunks) are provided via [`ClientConfig::with_snap`],
+    /// the association will skip the SCTP 4-way handshake (RFC 4960 Section 5.1)
+    /// and immediately transition to the ESTABLISHED state.
+    ///
+    /// Both `local_sctp_init` and `remote_sctp_init` must be provided for SNAP;
+    /// use [`generate_snap_token`](crate::generate_snap_token) to create the
+    /// local token.
+    ///
+    /// If only one side is set (e.g. the peer does not support SNAP), the
+    /// association falls back to the normal SCTP handshake.
+    ///
+    /// **Note:** When using SNAP, **both** peers must call [`Endpoint::connect`]
+    /// (there is no server-side SNAP via [`Endpoint::handle`]). Each peer
+    /// generates its own token via [`generate_snap_token`](crate::generate_snap_token),
+    /// exchanges it with the remote peer through a signaling channel (e.g.,
+    /// SDP `a=sctp-init`), and then calls `connect` with `with_snap(local, remote)`.
+    ///
+    /// See [draft-hancke-tsvwg-snap-01](https://datatracker.ietf.org/doc/draft-hancke-tsvwg-snap/).
     pub fn connect(
         &mut self,
         config: ClientConfig,
@@ -196,18 +216,180 @@ impl Endpoint {
             return Err(ConnectError::InvalidRemoteAddress(remote));
         }
 
-        let remote_aid = RandomAssociationIdGenerator::new().generate_aid();
-        let local_aid = self.new_aid();
+        match (config.local_sctp_init, config.remote_sctp_init) {
+            (Some(local_init), Some(remote_init)) => {
+                self.connect_with_snap(config.transport, remote, local_init, remote_init)
+            }
+            (partial_local, partial_remote) => {
+                if partial_local.is_some() || partial_remote.is_some() {
+                    warn!(
+                        "partial SNAP config: both local_sctp_init and \
+                        remote_sctp_init must be set; falling back to normal handshake"
+                    );
+                }
+                let remote_aid = RandomAssociationIdGenerator::new().generate_aid();
+                let local_aid = self.new_aid();
 
-        let (ch, conn) = self.add_association(
-            remote_aid,
-            local_aid,
+                Ok(self.add_association(
+                    remote_aid,
+                    local_aid,
+                    remote,
+                    None,
+                    Instant::now(),
+                    None,
+                    config.transport,
+                ))
+            }
+        }
+    }
+
+    /// Create an association using SNAP (out-of-band exchanged INIT chunks).
+    fn connect_with_snap(
+        &mut self,
+        transport: Arc<TransportConfig>,
+        remote: SocketAddr,
+        local_snap_bytes: Bytes,
+        remote_snap_bytes: Bytes,
+    ) -> Result<(AssociationHandle, Association), ConnectError> {
+        // Enforce a size ceiling on raw INIT bytes before parsing.
+        if local_snap_bytes.len() > MAX_SNAP_INIT_BYTES {
+            return Err(ConnectError::Snap(SnapError::OversizedInit {
+                side: SnapSide::Local,
+                len: local_snap_bytes.len(),
+            }));
+        }
+        if remote_snap_bytes.len() > MAX_SNAP_INIT_BYTES {
+            return Err(ConnectError::Snap(SnapError::OversizedInit {
+                side: SnapSide::Remote,
+                len: remote_snap_bytes.len(),
+            }));
+        }
+
+        let local_init = ChunkInit::unmarshal(&local_snap_bytes).map_err(|err| {
+            ConnectError::Snap(SnapError::ParseFailed {
+                side: SnapSide::Local,
+                reason: err.to_string(),
+            })
+        })?;
+        let remote_init = ChunkInit::unmarshal(&remote_snap_bytes).map_err(|err| {
+            ConnectError::Snap(SnapError::ParseFailed {
+                side: SnapSide::Remote,
+                reason: err.to_string(),
+            })
+        })?;
+
+        // Validate both chunks are INIT (not INIT-ACK)
+        if local_init.is_ack {
+            return Err(ConnectError::Snap(SnapError::InvalidInitAck {
+                side: SnapSide::Local,
+            }));
+        }
+        if remote_init.is_ack {
+            return Err(ConnectError::Snap(SnapError::InvalidInitAck {
+                side: SnapSide::Remote,
+            }));
+        }
+
+        let local_aid = local_init.initiate_tag;
+        let remote_aid = remote_init.initiate_tag;
+
+        // RFC 4960 Section 3.3.2: The Initiate Tag MUST NOT take the value 0.
+        if local_aid == 0 {
+            return Err(ConnectError::Snap(SnapError::ZeroInitiateTag {
+                side: SnapSide::Local,
+            }));
+        }
+        if remote_aid == 0 {
+            return Err(ConnectError::Snap(SnapError::ZeroInitiateTag {
+                side: SnapSide::Remote,
+            }));
+        }
+
+        // initial_tsn=0 is degenerate: wrapping_sub(1) yields u32::MAX for
+        // peer_last_tsn, which would accept nearly all incoming TSNs.
+        if local_init.initial_tsn == 0 {
+            return Err(ConnectError::Snap(SnapError::ZeroInitialTsn {
+                side: SnapSide::Local,
+            }));
+        }
+        if remote_init.initial_tsn == 0 {
+            return Err(ConnectError::Snap(SnapError::ZeroInitialTsn {
+                side: SnapSide::Remote,
+            }));
+        }
+
+        // RFC 4960 §3.3.2 / §5.1: validate stream counts, a_rwnd, etc.
+        local_init.check().map_err(|err| {
+            ConnectError::Snap(SnapError::InvalidInit {
+                side: SnapSide::Local,
+                reason: err.to_string(),
+            })
+        })?;
+        remote_init.check().map_err(|err| {
+            ConnectError::Snap(SnapError::InvalidInit {
+                side: SnapSide::Remote,
+                reason: err.to_string(),
+            })
+        })?;
+
+        // Check for collision BEFORE allocating any resources.
+        if local_aid == remote_aid {
+            return Err(ConnectError::Snap(SnapError::AidCollision {
+                kind: AidCollisionKind::LocalEqualsRemote,
+                aid: local_aid,
+            }));
+        }
+        if self.association_ids.contains_key(&local_aid) {
+            return Err(ConnectError::Snap(SnapError::AidCollision {
+                kind: AidCollisionKind::LocalInAssociationIds,
+                aid: local_aid,
+            }));
+        }
+        if self.association_ids.contains_key(&remote_aid) {
+            return Err(ConnectError::Snap(SnapError::AidCollision {
+                kind: AidCollisionKind::RemoteInAssociationIds,
+                aid: remote_aid,
+            }));
+        }
+        if self.association_ids_init.contains_key(&remote_aid) {
+            return Err(ConnectError::Snap(SnapError::AidCollision {
+                kind: AidCollisionKind::RemoteInAssociationIdsInit,
+                aid: remote_aid,
+            }));
+        }
+        if self.association_ids_init.contains_key(&local_aid) {
+            return Err(ConnectError::Snap(SnapError::AidCollision {
+                kind: AidCollisionKind::LocalInAssociationIdsInit,
+                aid: local_aid,
+            }));
+        }
+
+        let conn = Association::new_with_out_of_band_init(
+            transport,
+            self.config.get_max_payload_size(),
             remote,
             None,
-            Instant::now(),
-            None,
-            config.transport,
+            local_init,
+            remote_init,
+        )
+        .map_err(|err| ConnectError::Snap(SnapError::AssociationFailed(err.to_string())))?;
+
+        let id = self.associations.insert(AssociationMeta {
+            init_cid: remote_aid,
+            cids_issued: 1,
+            loc_cids: iter::once((0, local_aid)).collect(),
+            initial_remote: remote,
+        });
+
+        let ch = AssociationHandle(id);
+        self.association_ids.insert(local_aid, ch);
+        self.association_ids_init.insert(remote_aid, ch);
+
+        debug!(
+            "Created SNAP association: local_aid={:#x} remote_aid={:#x}",
+            local_aid, remote_aid
         );
+
         Ok((ch, conn))
     }
 
@@ -262,6 +444,10 @@ impl Endpoint {
             transport_config,
         );
 
+        // Map the peer's INIT Initiate Tag so that retransmitted INITs (which use
+        // verification_tag=0) can be routed to the association created for the first INIT.
+        self.association_ids_init.insert(remote_aid, ch);
+
         conn.handle_event(AssociationEvent(AssociationEventInner::Datagram(
             Transmit {
                 now,
@@ -298,7 +484,7 @@ impl Endpoint {
 
         let id = self.associations.insert(AssociationMeta {
             init_cid: remote_aid,
-            cids_issued: 0,
+            cids_issued: 1,
             loc_cids: iter::once((0, local_aid)).collect(),
             initial_remote: remote_addr,
         });
@@ -399,4 +585,122 @@ pub enum ConnectError {
     /// Use `Endpoint::connect_with` to specify a client configuration.
     #[error("no default client config")]
     NoDefaultClientConfig,
+    /// Out-of-band SNAP setup error.
+    #[error("SNAP error: {0}")]
+    Snap(#[from] SnapError),
+}
+
+/// Which peer's token (INIT chunk) caused a [`SnapError`].
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SnapSide {
+    /// The locally-generated token.
+    Local,
+    /// The remote peer's token.
+    Remote,
+}
+
+impl fmt::Display for SnapSide {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            SnapSide::Local => f.write_str("local"),
+            SnapSide::Remote => f.write_str("remote"),
+        }
+    }
+}
+
+/// Which routing table detected an association-ID collision in [`SnapError::AidCollision`].
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AidCollisionKind {
+    /// The local and remote association IDs are equal.
+    LocalEqualsRemote,
+    /// The local AID is already present in `association_ids`.
+    LocalInAssociationIds,
+    /// The remote AID is already present in `association_ids`.
+    RemoteInAssociationIds,
+    /// The remote AID is already present in `association_ids_init`.
+    RemoteInAssociationIdsInit,
+    /// The local AID is already present in `association_ids_init`.
+    LocalInAssociationIdsInit,
+}
+
+impl fmt::Display for AidCollisionKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            AidCollisionKind::LocalEqualsRemote => f.write_str("local_aid equals remote_aid"),
+            AidCollisionKind::LocalInAssociationIds => f.write_str("local_aid in association_ids"),
+            AidCollisionKind::RemoteInAssociationIds => {
+                f.write_str("remote_aid in association_ids")
+            }
+            AidCollisionKind::RemoteInAssociationIdsInit => {
+                f.write_str("remote_aid in association_ids_init")
+            }
+            AidCollisionKind::LocalInAssociationIdsInit => {
+                f.write_str("local_aid in association_ids_init")
+            }
+        }
+    }
+}
+
+/// Specific errors that can occur during SNAP (out-of-band token) setup.
+///
+/// These are not part of the stable API — match on [`ConnectError::Snap`]
+/// and use the `Display` impl for user-facing messages.
+#[non_exhaustive]
+#[derive(Debug, Error, Clone, PartialEq, Eq)]
+pub enum SnapError {
+    /// Failed to parse token (INIT chunk) bytes.
+    #[error("failed to parse {side} SNAP token: {reason}")]
+    ParseFailed {
+        /// Which side's token failed to parse.
+        side: SnapSide,
+        /// The underlying parse error message.
+        reason: String,
+    },
+    /// The provided bytes were an INIT-ACK, not an INIT.
+    #[error("invalid {side} SNAP token: expected INIT, got INIT-ACK")]
+    InvalidInitAck {
+        /// Which side provided an INIT-ACK instead of an INIT.
+        side: SnapSide,
+    },
+    /// The token's `initiate_tag` is zero (RFC 4960 §3.3.2 violation).
+    #[error("{side} SNAP token has zero initiate_tag")]
+    ZeroInitiateTag {
+        /// Which side has the zero tag.
+        side: SnapSide,
+    },
+    /// The token's `initial_tsn` is zero.
+    #[error("{side} SNAP token has zero initial_tsn")]
+    ZeroInitialTsn {
+        /// Which side has the zero TSN.
+        side: SnapSide,
+    },
+    /// An association ID collision was detected.
+    #[error("SNAP collision: {kind} {aid:#x} already in use")]
+    AidCollision {
+        /// Which routing table collided.
+        kind: AidCollisionKind,
+        /// The colliding association ID.
+        aid: u32,
+    },
+    /// The token (INIT chunk) bytes exceed the maximum allowed size.
+    #[error("{side} SNAP token too large: {len} bytes (max {max})", max = MAX_SNAP_INIT_BYTES)]
+    OversizedInit {
+        /// Which side sent oversized bytes.
+        side: SnapSide,
+        /// Actual byte length.
+        len: usize,
+    },
+    /// The parsed token (INIT chunk) failed RFC 4960 validation.
+    #[error("invalid {side} SNAP token: {reason}")]
+    InvalidInit {
+        /// Which side has the invalid token.
+        side: SnapSide,
+        /// The underlying validation error message.
+        reason: String,
+    },
+    /// Association creation failed.
+    #[error("failed to create SNAP association: {0}")]
+    AssociationFailed(String),
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,10 +72,15 @@ pub use crate::chunk::ErrorCauseCode;
 pub use crate::chunk::chunk_payload_data::{ChunkPayloadData, PayloadProtocolIdentifier};
 
 mod config;
-pub use crate::config::{ClientConfig, EndpointConfig, ServerConfig, TransportConfig};
+pub use crate::config::{
+    ClientConfig, DEFAULT_SCTP_PORT, EndpointConfig, MAX_SNAP_INIT_BYTES, ServerConfig,
+    TransportConfig, generate_snap_token,
+};
 
 mod endpoint;
-pub use crate::endpoint::{AssociationHandle, ConnectError, DatagramEvent, Endpoint};
+pub use crate::endpoint::{
+    AidCollisionKind, AssociationHandle, ConnectError, DatagramEvent, Endpoint, SnapError, SnapSide,
+};
 
 mod error;
 pub use crate::error::Error;


### PR DESCRIPTION
Implements SCTP Negotiation Acceleration Protocol ([draft-hancke-tsvwg-snap-01](https://datatracker.ietf.org/doc/draft-hancke-tsvwg-snap/)), allowing associations to skip the SCTP 4-way handshake by exchanging INIT chunks out-of-band via a signaling channel (e.g., SDP `a=sctp-init`).

Based on [pion/sctp#449](https://github.com/pion/sctp/pull/449).

### New public API

| Item | Description |
|------|-------------|
| `generate_snap_token(&TransportConfig)` | Generates a serialized SCTP INIT chunk with random tags for exchange via signaling |
| `ClientConfig::with_snap(local, remote)` | Enables SNAP with local and remote INIT bytes |
| `SnapError` | `#[non_exhaustive]` error enum for SNAP-specific failures |
| `SnapSide` | `#[non_exhaustive]` enum identifying which peer's token caused an error |
| `AidCollisionKind` | `#[non_exhaustive]` enum for association-ID collision categories |
| `DEFAULT_SCTP_PORT` | Constant (5000) |
| `MAX_SNAP_INIT_BYTES` | Max allowed INIT size (2048 bytes) |

### How it works

1. Both peers call `generate_snap_token()` and exchange the bytes via signaling
2. Both peers call `Endpoint::connect()` with `ClientConfig::with_snap(local, remote)`
3. The association skips INIT/INIT-ACK/COOKIE-ECHO/COOKIE-ACK and goes straight to ESTABLISHED

If only one side provides SNAP config, it falls back to the normal handshake with a warning.

### Refactoring

- Extracted `Association::new_common()` — shared initialization between normal and SNAP paths
- Extracted `apply_remote_init_params()` — deduplicates remote INIT parameter handling from `handle_init`, `handle_init_ack`, and the new SNAP path
- Uses `wrapping_sub` for TSN arithmetic instead of manual `if tsn == 0 { u32::MAX } else { tsn - 1 }`
- Uses `NonZeroU32` for random tag/TSN generation instead of `if random == 0 { random += 1 }`

### Validation (SNAP path)

- Size limit on INIT bytes before parsing (`MAX_SNAP_INIT_BYTES`)
- Rejects INIT-ACK (must be INIT)
- Rejects zero `initiate_tag` (RFC 4960 §3.3.2)
- Rejects zero `initial_tsn` (prevents degenerate `peer_last_tsn = u32::MAX`)
- Runs `ChunkInit::check()` on both tokens (stream counts, a_rwnd ≥ 1500)
- `generate_snap_token` also calls `check()` to catch invalid `TransportConfig` at generation time
- Collision detection against existing association IDs (typed via `AidCollisionKind`)
- RFC-correct stream cross-negotiation: `min(my_inbound, their_outbound)`

### Bug fixes (unrelated to SNAP)

- `cids_issued` initialized to `1` instead of `0` (was off-by-one — one CID already exists at creation)
- Hardcoded port `5000` moved to `DEFAULT_SCTP_PORT` constant
- `association_ids_init` now also populated for normal (non-SNAP) server associations so retransmitted INITs can be routed
- Fixed RFC reference typo: "RFC 4690" → "RFC 4960"

### Tests

~31 new tests covering SNAP connection establishment, bidirectional data transmission, error cases (invalid bytes, truncated, oversized, garbage, wrong chunk type, zero tags, zero TSN, zero streams, small a_rwnd, INIT-ACK rejection, collisions), partial config fallback, drain cleanup, token generation roundtrip/uniqueness, and retransmitted INIT routing.