### PR TITLE
Add fuzz testing for packet unmarshal

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -1,0 +1,52 @@
+name: Fuzz
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+  # Allow manual trigger
+  workflow_dispatch:
+  # Run fuzz tests daily
+  schedule:
+    - cron: '0 0 * * *'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  fuzz:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          - fuzz_packet_unmarshal
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: nightly
+      - name: Install cargo-fuzz
+        run: cargo install cargo-fuzz
+      - name: Cache fuzz corpus
+        uses: actions/cache@v5
+        with:
+          path: fuzz/corpus
+          key: fuzz-corpus-${{ matrix.target }}-${{ github.sha }}
+          restore-keys: |
+            fuzz-corpus-${{ matrix.target }}-
+      - name: Run fuzz target
+        run: |
+          cargo fuzz run ${{ matrix.target }} -- \
+            -max_total_time=60 \
+            -max_len=65536
+      - name: Upload crash artifacts
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: crash-${{ matrix.target }}
+          path: fuzz/artifacts/${{ matrix.target }}/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,10 @@ categories = ["network-programming", "asynchronous"]
 
 rust-version = "1.85"
 
+[features]
+# Expose internals for fuzz testing. Not part of the public API.
+_fuzz = []
+
 [dependencies]
 bytes = "1.5.0"
 rand = "0.9"

--- a/fuzz/.gitignore
+++ b/fuzz/.gitignore
@@ -1,0 +1,3 @@
+target
+corpus
+artifacts

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "sctp-proto-fuzz"
+version = "0.0.0"
+publish = false
+edition = "2024"
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = "0.4"
+
+[dependencies.sctp-proto]
+path = ".."
+features = ["_fuzz"]
+
+[[bin]]
+name = "fuzz_packet_unmarshal"
+path = "fuzz_targets/fuzz_packet_unmarshal.rs"
+test = false
+doc = false
+bench = false

--- a/fuzz/fuzz_targets/fuzz_packet_unmarshal.rs
+++ b/fuzz/fuzz_targets/fuzz_packet_unmarshal.rs
@@ -1,0 +1,13 @@
+#![no_main]
+
+//! Fuzz target for SCTP packet unmarshalling.
+//!
+//! Feeds arbitrary bytes with a valid CRC32C checksum into
+//! `Packet::unmarshal` to find panics or other issues in
+//! the parsing logic.
+
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| {
+    sctp_proto::_fuzz::fuzz_packet_unmarshal(data);
+});

--- a/src/chunk/chunk_abort.rs
+++ b/src/chunk/chunk_abort.rs
@@ -55,12 +55,11 @@ impl Chunk for ChunkAbort {
             return Err(Error::ErrChunkTypeNotAbort);
         }
 
+        let value_end = CHUNK_HEADER_SIZE + header.value_length();
         let mut error_causes = vec![];
         let mut offset = CHUNK_HEADER_SIZE;
-        while offset + 4 <= raw.len() {
-            let e = ErrorCause::unmarshal(
-                &raw.slice(offset..CHUNK_HEADER_SIZE + header.value_length()),
-            )?;
+        while offset + ERROR_CAUSE_HEADER_LENGTH <= value_end {
+            let e = ErrorCause::unmarshal(&raw.slice(offset..value_end))?;
             offset += e.length();
             error_causes.push(e);
         }

--- a/src/chunk/chunk_error.rs
+++ b/src/chunk/chunk_error.rs
@@ -57,12 +57,11 @@ impl Chunk for ChunkError {
             return Err(Error::ErrChunkTypeNotCt);
         }
 
+        let value_end = CHUNK_HEADER_SIZE + header.value_length();
         let mut error_causes = vec![];
         let mut offset = CHUNK_HEADER_SIZE;
-        while offset + 4 <= raw.len() {
-            let e = ErrorCause::unmarshal(
-                &raw.slice(offset..CHUNK_HEADER_SIZE + header.value_length()),
-            )?;
+        while offset + ERROR_CAUSE_HEADER_LENGTH <= value_end {
+            let e = ErrorCause::unmarshal(&raw.slice(offset..value_end))?;
             offset += e.length();
             error_causes.push(e);
         }

--- a/src/chunk/chunk_forward_tsn.rs
+++ b/src/chunk/chunk_forward_tsn.rs
@@ -62,20 +62,19 @@ impl Chunk for ChunkForwardTsn {
             return Err(Error::ErrChunkTypeNotForwardTsn);
         }
 
-        let mut offset = CHUNK_HEADER_SIZE + NEW_CUMULATIVE_TSN_LENGTH;
-        if buf.len() < offset {
+        if header.value_length() < NEW_CUMULATIVE_TSN_LENGTH {
             return Err(Error::ErrChunkTooShort);
         }
 
+        let mut offset = CHUNK_HEADER_SIZE + NEW_CUMULATIVE_TSN_LENGTH;
         let reader = &mut buf.slice(CHUNK_HEADER_SIZE..CHUNK_HEADER_SIZE + header.value_length());
         let new_cumulative_tsn = reader.get_u32();
 
         let mut streams = vec![];
-        let mut remaining = buf.len() - offset;
+        let value_end = CHUNK_HEADER_SIZE + header.value_length();
+        let mut remaining = value_end - offset;
         while remaining > 0 {
-            let s = ChunkForwardTsnStream::unmarshal(
-                &buf.slice(offset..CHUNK_HEADER_SIZE + header.value_length()),
-            )?;
+            let s = ChunkForwardTsnStream::unmarshal(&buf.slice(offset..value_end))?;
             offset += s.value_length();
             remaining -= s.value_length();
             streams.push(s);

--- a/src/chunk/chunk_heartbeat.rs
+++ b/src/chunk/chunk_heartbeat.rs
@@ -55,7 +55,7 @@ impl Chunk for ChunkHeartbeat {
             return Err(Error::ErrChunkTypeNotHeartbeat);
         }
 
-        if raw.len() <= CHUNK_HEADER_SIZE {
+        if header.value_length() < PARAM_HEADER_LENGTH {
             return Err(Error::ErrHeartbeatNotLongEnoughInfo);
         }
 

--- a/src/chunk/chunk_heartbeat_ack.rs
+++ b/src/chunk/chunk_heartbeat_ack.rs
@@ -57,7 +57,7 @@ impl Chunk for ChunkHeartbeatAck {
             return Err(Error::ErrChunkTypeNotHeartbeatAck);
         }
 
-        if raw.len() <= CHUNK_HEADER_SIZE {
+        if header.value_length() < PARAM_HEADER_LENGTH {
             return Err(Error::ErrHeartbeatNotLongEnoughInfo);
         }
 

--- a/src/chunk/chunk_i_forward_tsn.rs
+++ b/src/chunk/chunk_i_forward_tsn.rs
@@ -1,4 +1,4 @@
-use super::{chunk_header::*, chunk_type::*, *};
+use super::{chunk_forward_tsn::NEW_CUMULATIVE_TSN_LENGTH, chunk_header::*, chunk_type::*, *};
 use alloc::string::ToString;
 
 /// I-FORWARD-TSN chunk (RFC 8260).
@@ -58,7 +58,7 @@ impl Chunk for ChunkIForwardTsn {
         }
 
         let value_end = CHUNK_HEADER_SIZE + header.value_length();
-        if buf.len() < CHUNK_HEADER_SIZE + 4 {
+        if header.value_length() < NEW_CUMULATIVE_TSN_LENGTH {
             return Err(Error::ErrChunkTooShort);
         }
 
@@ -66,7 +66,7 @@ impl Chunk for ChunkIForwardTsn {
         let new_cumulative_tsn = reader.get_u32();
 
         let mut streams = vec![];
-        let mut offset = CHUNK_HEADER_SIZE + 4;
+        let mut offset = CHUNK_HEADER_SIZE + NEW_CUMULATIVE_TSN_LENGTH;
         while offset + I_FORWARD_TSN_STREAM_ENTRY_LENGTH <= value_end {
             let entry_buf = &mut buf.slice(offset..value_end);
             let identifier = entry_buf.get_u16();

--- a/src/chunk/chunk_init.rs
+++ b/src/chunk/chunk_init.rs
@@ -131,7 +131,7 @@ impl Chunk for ChunkInit {
 
         if !(header.typ == CT_INIT || header.typ == CT_INIT_ACK) {
             return Err(Error::ErrChunkTypeNotTypeInit);
-        } else if raw.len() < CHUNK_HEADER_SIZE + INIT_CHUNK_MIN_LENGTH {
+        } else if header.value_length() < INIT_CHUNK_MIN_LENGTH {
             return Err(Error::ErrChunkValueNotLongEnough);
         }
 
@@ -152,7 +152,8 @@ impl Chunk for ChunkInit {
 
         let mut params = vec![];
         let mut offset = CHUNK_HEADER_SIZE + INIT_CHUNK_MIN_LENGTH;
-        let mut remaining = raw.len() as isize - offset as isize;
+        let value_end = CHUNK_HEADER_SIZE + header.value_length();
+        let mut remaining = value_end as isize - offset as isize;
         while remaining > INIT_OPTIONAL_VAR_HEADER_LENGTH as isize {
             let p = build_param(&raw.slice(offset..CHUNK_HEADER_SIZE + header.value_length()))?;
             let p_len = PARAM_HEADER_LENGTH + p.value_length();

--- a/src/chunk/chunk_payload_data.rs
+++ b/src/chunk/chunk_payload_data.rs
@@ -182,7 +182,7 @@ impl Chunk for ChunkPayloadData {
         let beginning_fragment = (header.flags & PAYLOAD_DATA_BEGINING_FRAGMENT_BITMASK) != 0;
         let ending_fragment = (header.flags & PAYLOAD_DATA_ENDING_FRAGMENT_BITMASK) != 0;
 
-        if raw.len() < PAYLOAD_DATA_HEADER_SIZE {
+        if header.value_length() < PAYLOAD_DATA_HEADER_SIZE {
             return Err(Error::ErrChunkPayloadSmall);
         }
 

--- a/src/chunk/chunk_reconfig.rs
+++ b/src/chunk/chunk_reconfig.rs
@@ -63,6 +63,10 @@ impl Chunk for ChunkReconfig {
             return Err(Error::ErrChunkTypeNotReconfig);
         }
 
+        if header.value_length() < PARAM_HEADER_LENGTH {
+            return Err(Error::ErrChunkTooShort);
+        }
+
         let param_a =
             build_param(&raw.slice(CHUNK_HEADER_SIZE..CHUNK_HEADER_SIZE + header.value_length()))?;
 

--- a/src/chunk/chunk_selective_ack.rs
+++ b/src/chunk/chunk_selective_ack.rs
@@ -87,7 +87,7 @@ impl Chunk for ChunkSelectiveAck {
             return Err(Error::ErrChunkTypeNotSack);
         }
 
-        if raw.len() < CHUNK_HEADER_SIZE + SELECTIVE_ACK_HEADER_SIZE {
+        if header.value_length() < SELECTIVE_ACK_HEADER_SIZE {
             return Err(Error::ErrSackSizeNotLargeEnoughInfo);
         }
 
@@ -98,13 +98,11 @@ impl Chunk for ChunkSelectiveAck {
         let gap_ack_blocks_len = reader.get_u16() as usize;
         let duplicate_tsn_len = reader.get_u16() as usize;
 
-        // Here we must account for case where the buffer contains another chunk
-        // right after this one. Testing for equality would incorrectly fail the
-        // parsing of this chunk and incorrectly close the transport.
-        if raw.len()
-            < CHUNK_HEADER_SIZE
-                + SELECTIVE_ACK_HEADER_SIZE
-                + (4 * gap_ack_blocks_len + 4 * duplicate_tsn_len)
+        // The reader is bounded by header.value_length(), so we
+        // must check against that, not raw.len() which may include
+        // subsequent chunks.
+        if header.value_length()
+            < SELECTIVE_ACK_HEADER_SIZE + (4 * gap_ack_blocks_len + 4 * duplicate_tsn_len)
         {
             return Err(Error::ErrSackSizeNotLargeEnoughInfo);
         }

--- a/src/chunk/chunk_shutdown.rs
+++ b/src/chunk/chunk_shutdown.rs
@@ -39,7 +39,7 @@ impl Chunk for ChunkShutdown {
             return Err(Error::ErrChunkTypeNotShutdown);
         }
 
-        if raw.len() != CHUNK_HEADER_SIZE + CUMULATIVE_TSN_ACK_LENGTH {
+        if header.value_length() != CUMULATIVE_TSN_ACK_LENGTH {
             return Err(Error::ErrInvalidChunkSize);
         }
 

--- a/src/chunk/mod.rs
+++ b/src/chunk/mod.rs
@@ -152,6 +152,9 @@ impl ErrorCause {
         }
 
         let value_length = len as usize - ERROR_CAUSE_HEADER_LENGTH;
+        if buf.len() < ERROR_CAUSE_HEADER_LENGTH + value_length {
+            return Err(Error::ErrErrorCauseTooSmall);
+        }
         let raw = buf.slice(ERROR_CAUSE_HEADER_LENGTH..ERROR_CAUSE_HEADER_LENGTH + value_length);
 
         Ok(ErrorCause { code, raw })

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,6 +94,37 @@ pub use crate::queue::reassembly_queue::{Chunk, Chunks};
 
 pub(crate) mod util;
 
+/// Fuzz helpers. Not part of the public API.
+#[cfg(feature = "_fuzz")]
+pub mod _fuzz {
+    use bytes::BytesMut;
+
+    use crate::packet::Packet;
+    use crate::util::generate_packet_checksum;
+
+    /// Feed arbitrary bytes into packet unmarshal.
+    ///
+    /// Patches a valid CRC32C checksum so the fuzzer can
+    /// reach the parsing logic beyond the checksum check.
+    pub fn fuzz_packet_unmarshal(data: &[u8]) {
+        if data.len() < 12 {
+            return;
+        }
+        let mut buf = BytesMut::from(data);
+        // Zero checksum field before computing
+        buf[8] = 0;
+        buf[9] = 0;
+        buf[10] = 0;
+        buf[11] = 0;
+        let raw = buf.freeze();
+        let checksum = generate_packet_checksum(&raw);
+        let mut buf = BytesMut::from(raw.as_ref());
+        buf[8..12].copy_from_slice(&checksum.to_le_bytes());
+        let raw = buf.freeze();
+        let _ = Packet::unmarshal(&raw);
+    }
+}
+
 /// Whether an endpoint was the initiator of an association
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Default)]
 pub enum Side {

--- a/src/packet.rs
+++ b/src/packet.rs
@@ -55,6 +55,7 @@ use core::fmt;
 ///|                           Checksum                            |
 ///+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 pub(crate) const PACKET_HEADER_SIZE: usize = 12;
+const INITIATE_TAG_LENGTH: usize = 4;
 
 #[derive(Default, Debug)]
 pub(crate) struct CommonHeader {
@@ -101,13 +102,17 @@ impl PartialDecode {
         let mut cookie = None;
         match header.typ {
             CT_INIT | CT_INIT_ACK => {
+                if header.value_length() < INITIATE_TAG_LENGTH {
+                    return Err(Error::ErrChunkValueNotLongEnough);
+                }
                 initiate_tag = Some(reader.get_u32());
             }
             CT_COOKIE_ECHO => {
-                cookie = Some(raw.slice(
-                    PACKET_HEADER_SIZE + CHUNK_HEADER_SIZE
-                        ..PACKET_HEADER_SIZE + CHUNK_HEADER_SIZE + header.value_length(),
-                ));
+                let end = PACKET_HEADER_SIZE + CHUNK_HEADER_SIZE + header.value_length();
+                if end > raw.len() {
+                    return Err(Error::ErrChunkValueNotLongEnough);
+                }
+                cookie = Some(raw.slice(PACKET_HEADER_SIZE + CHUNK_HEADER_SIZE..end));
             }
             _ => {}
         }

--- a/src/param/param_outgoing_reset_request.rs
+++ b/src/param/param_outgoing_reset_request.rs
@@ -71,8 +71,7 @@ impl Param for ParamOutgoingResetRequest {
 
     fn unmarshal(raw: &Bytes) -> Result<Self> {
         let header = ParamHeader::unmarshal(raw)?;
-        if raw.len() < PARAM_HEADER_LENGTH + PARAM_OUTGOING_RESET_REQUEST_STREAM_IDENTIFIERS_OFFSET
-        {
+        if header.value_length() < PARAM_OUTGOING_RESET_REQUEST_STREAM_IDENTIFIERS_OFFSET {
             return Err(Error::ErrSsnResetRequestParamTooShort);
         }
 

--- a/src/param/param_reconfig_response.rs
+++ b/src/param/param_reconfig_response.rs
@@ -98,7 +98,7 @@ impl Param for ParamReconfigResponse {
 
     fn unmarshal(raw: &Bytes) -> Result<Self> {
         let header = ParamHeader::unmarshal(raw)?;
-        if raw.len() < 8 + PARAM_HEADER_LENGTH {
+        if header.value_length() < 8 {
             return Err(Error::ErrReconfigRespParamTooShort);
         }
 


### PR DESCRIPTION
This is probably pretty low risk as the other implementation is trusted after DTLS and CRC check.

But low cost to have so maybe better safe than sorry?

Ok, also fixed things that was panic with fuzzed inputs