### PR TITLE
Fix cwnd computation for small MTU sizes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+  * Fix cwnd computation panic for small MTU sizes #47
   * Bump rand 0.9.2 -> 0.9.4 to address RUSTSEC-2026-0097 #48
 
 # 0.9.0
@@ -14,14 +15,14 @@
   * Downgrade rand to 0.9 to avoid double chacha20 dep #39
 
 # 0.8.0 (yanked)
-  
+
   * Add I-FORWARD-TSN (RFC 8260) chunk support #29
   * MSRV 1.85, Edition 2024, bump deps #38
   * Enforce receive-side max message size #27
 
 # 0.7.1
 
-  * Fix server-side rwnd initialization from INIT #28 
+  * Fix server-side rwnd initialization from INIT #28
 
 # 0.7.0
 

--- a/src/association/association_test.rs
+++ b/src/association/association_test.rs
@@ -1013,3 +1013,26 @@ fn test_out_of_band_rwnd_negotiation() {
         "rwnd should be remote's advertised window"
     );
 }
+
+#[test]
+fn test_initial_cwnd_small_mtu() {
+    // Regression test for #47: a small MTU made 4*MTU < 4380, which previously
+    // panicked because clamp(4380, 4*MTU) was called with min > max.
+    let max_payload_size = 100;
+    let mtu = max_payload_size + COMMON_HEADER_SIZE + DATA_CHUNK_HEADER_SIZE;
+    assert!(4 * mtu < 4380, "test must exercise the small-MTU branch");
+
+    let assoc = Association::new(
+        None,
+        Arc::new(TransportConfig::default()),
+        max_payload_size,
+        0,
+        SocketAddr::from_str("0.0.0.0:0").unwrap(),
+        None,
+        Instant::now(),
+    );
+
+    // RFC 4960 Sec 7.2.1: min(4*MTU, max(2*MTU, 4380)).
+    assert_eq!(assoc.cwnd, (4 * mtu).min((2 * mtu).max(4380)));
+    assert_eq!(assoc.cwnd, 4 * mtu);
+}

--- a/src/association/mod.rs
+++ b/src/association/mod.rs
@@ -336,7 +336,7 @@ impl Association {
         // RFC 4960 Sec 7.2.1
         // The initial cwnd before DATA transmission or after a sufficiently
         // long idle period MUST be set to min(4*MTU, max (2*MTU, 4380bytes)).
-        let cwnd = (2 * mtu).clamp(4380, 4 * mtu);
+        let cwnd = (4 * mtu).min((2 * mtu).max(4380));
 
         Association {
             side,


### PR DESCRIPTION
The existing implementation with .clamp(4380, 4 * mtu) crashes when 4380 > 4 * mtu .