### PR TITLE
Bump rand to 0.9.4 (RUSTSEC-2026-0097)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+  * Bump rand 0.9.2 -> 0.9.4 to address RUSTSEC-2026-0097 #48
+
 # 0.9.0
 
   * Add support for out of band negotiation for SNAP #34

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -94,9 +94,9 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha",
  "rand_core",


### PR DESCRIPTION
## What

Bumps `rand` 0.9.2 → 0.9.4 (lockfile only) to resolve [RUSTSEC-2026-0097](https://rustsec.org/advisories/RUSTSEC-2026-0097): an unsoundness advisory in `rand` when a custom logger calls `rand::rng()` while reseeding.

## Why now

This is failing cargo-deny on open PRs (e.g. #47), but it is **not** introduced by any of them — `main` pins the same `rand 0.9.2`. The advisory was published 2026-04-09, after `main`'s last push (2026-03-24), so cargo-deny simply hasn't re-run on `main` since. Fixing it on `main` unblocks the other PRs.

## Notes

- Lockfile-only change; `Cargo.toml` is untouched.
- Cargo's MSRV-aware resolver locks to the latest **Rust 1.85-compatible** version (0.9.4), deliberately not 0.10.x.
- Only `rand` changes — no transitive bumps, no new duplicate versions (keeps `multiple-versions = "deny"` happy).
- `cargo msrv verify` passes on the declared MSRV (1.85.0).
