### PR TITLE
Calculate message length in the reassembly queue

### DIFF
--- a/src/queue/queue_test.rs
+++ b/src/queue/queue_test.rs
@@ -1100,3 +1100,58 @@ fn test_reassembly_queue_wrap_find_complete() {
         "chunkSet with wrapping TSNs is not complete"
     );
 }
+
+#[test]
+fn test_reassembly_queue_max_message_size() {
+    let mut rq = ReassemblyQueue::new(0, 65536);
+    rq.max_message_size = 15;
+
+    assert_eq!(
+        rq.push(ChunkPayloadData {
+            tsn: 100,
+            beginning_fragment: true,
+            unordered: true,
+            user_data: Bytes::from_owner([0; 5]),
+            ..Default::default()
+        }),
+        Ok(false)
+    );
+    assert_eq!(
+        rq.push(ChunkPayloadData {
+            tsn: 102,
+            ending_fragment: true,
+            unordered: true,
+            user_data: Bytes::from_owner([0; 5]),
+            ..Default::default()
+        }),
+        Ok(false)
+    );
+    assert_eq!(
+        rq.push(ChunkPayloadData {
+            tsn: 103,
+            beginning_fragment: true,
+            unordered: true,
+            user_data: Bytes::from_owner([0; 5]),
+            ..Default::default()
+        }),
+        Ok(false)
+    );
+    assert_eq!(
+        rq.push(ChunkPayloadData {
+            tsn: 104,
+            unordered: true,
+            user_data: Bytes::from_owner([0; 5]),
+            ..Default::default()
+        }),
+        Ok(false)
+    );
+    assert_eq!(
+        rq.push(ChunkPayloadData {
+            tsn: 101,
+            unordered: true,
+            user_data: Bytes::from_owner([0; 5]),
+            ..Default::default()
+        }),
+        Ok(true)
+    );
+}

--- a/src/queue/queue_test.rs
+++ b/src/queue/queue_test.rs
@@ -1036,3 +1036,67 @@ fn test_reassembly_queue_ssn_overflow_in_forward_tsn_for_ordered() -> Result<()>
 
     Ok(())
 }
+
+#[test]
+fn test_chunk_set_wrap() {
+    let cset = Chunks::new(
+        0,
+        PayloadProtocolIdentifier::default(),
+        vec![
+            ChunkPayloadData {
+                tsn: u32::MAX - 1,
+                beginning_fragment: true,
+                ..Default::default()
+            },
+            ChunkPayloadData {
+                tsn: u32::MAX,
+                ..Default::default()
+            },
+            ChunkPayloadData {
+                tsn: 0,
+                ending_fragment: true,
+                ..Default::default()
+            },
+        ],
+    );
+
+    assert!(
+        cset.is_complete(),
+        "chunkSet with wrapping TSNs is not complete"
+    );
+}
+
+#[test]
+fn test_reassembly_queue_wrap_find_complete() {
+    let mut rq = ReassemblyQueue::new(0, 65535);
+
+    assert!(rq
+        .push(ChunkPayloadData {
+            tsn: u32::MAX - 1,
+            unordered: true,
+            beginning_fragment: true,
+            ..Default::default()
+        })
+        .is_ok());
+    assert!(rq
+        .push(ChunkPayloadData {
+            tsn: u32::MAX,
+            unordered: true,
+            ..Default::default()
+        })
+        .is_ok());
+    assert!(rq
+        .push(ChunkPayloadData {
+            tsn: 0,
+            unordered: true,
+            ending_fragment: true,
+            ..Default::default()
+        })
+        .is_ok());
+
+    assert_eq!(
+        rq.unordered.len(),
+        1,
+        "chunkSet with wrapping TSNs is not complete"
+    );
+}

--- a/src/queue/queue_test.rs
+++ b/src/queue/queue_test.rs
@@ -1070,29 +1070,32 @@ fn test_chunk_set_wrap() {
 fn test_reassembly_queue_wrap_find_complete() {
     let mut rq = ReassemblyQueue::new(0, 65535);
 
-    assert!(rq
-        .push(ChunkPayloadData {
+    assert!(
+        rq.push(ChunkPayloadData {
             tsn: u32::MAX - 1,
             unordered: true,
             beginning_fragment: true,
             ..Default::default()
         })
-        .is_ok());
-    assert!(rq
-        .push(ChunkPayloadData {
+        .is_ok()
+    );
+    assert!(
+        rq.push(ChunkPayloadData {
             tsn: u32::MAX,
             unordered: true,
             ..Default::default()
         })
-        .is_ok());
-    assert!(rq
-        .push(ChunkPayloadData {
+        .is_ok()
+    );
+    assert!(
+        rq.push(ChunkPayloadData {
             tsn: 0,
             unordered: true,
             ending_fragment: true,
             ..Default::default()
         })
-        .is_ok());
+        .is_ok()
+    );
 
     assert_eq!(
         rq.unordered.len(),

--- a/src/queue/reassembly_queue.rs
+++ b/src/queue/reassembly_queue.rs
@@ -288,12 +288,12 @@ impl ReassemblyQueue {
         } else if let Some(mut p) = self
             .unordered_chunks
             .iter()
-            .rposition(|f| f.tsn == (new_chunk.tsn - 1))
+            .rposition(|f| f.tsn == new_chunk.tsn.wrapping_sub(1))
         {
             let mut cnt = 0;
             let mut tsn = new_chunk.tsn;
             loop {
-                if self.unordered_chunks[p].tsn == tsn - 1 {
+                if self.unordered_chunks[p].tsn == tsn.wrapping_sub(1) {
                     cnt += self.unordered_chunks[p].user_data.len();
                     tsn = self.unordered_chunks[p].tsn;
                 } else {
@@ -316,12 +316,12 @@ impl ReassemblyQueue {
         } else if let Some(mut p) = self
             .unordered_chunks
             .iter()
-            .rposition(|f| f.tsn == (new_chunk.tsn + 1))
+            .rposition(|f| f.tsn == new_chunk.tsn.wrapping_add(1))
         {
             let mut cnt = 0;
             let mut tsn = new_chunk.tsn;
             while p < self.unordered_chunks.len() {
-                if self.unordered_chunks[p].tsn == tsn + 1 {
+                if self.unordered_chunks[p].tsn == tsn.wrapping_add(1) {
                     cnt += self.unordered_chunks[p].user_data.len();
                     tsn = self.unordered_chunks[p].tsn;
                 } else {

--- a/src/queue/reassembly_queue.rs
+++ b/src/queue/reassembly_queue.rs
@@ -281,12 +281,65 @@ impl ReassemblyQueue {
     fn calculate_unordered_message_size(&self, new_chunk: &ChunkPayloadData) -> usize {
         // For unordered, calculate size of contiguous chunk set this belongs to
         // This is more complex - need to find the message boundary
-        // Simplified: sum all unordered chunks + new chunk (conservative)
-        self.unordered_chunks
+
+        // first find the set of TSNs that preceeds this chunk
+        let prefix = if new_chunk.beginning_fragment {
+            0
+        } else if let Some(mut p) = self
+            .unordered_chunks
             .iter()
-            .map(|c| c.user_data.len())
-            .sum::<usize>()
-            + new_chunk.user_data.len()
+            .rposition(|f| f.tsn == (new_chunk.tsn - 1))
+        {
+            let mut cnt = 0;
+            let mut tsn = new_chunk.tsn;
+            loop {
+                if self.unordered_chunks[p].tsn == tsn - 1 {
+                    cnt += self.unordered_chunks[p].user_data.len();
+                    tsn = self.unordered_chunks[p].tsn;
+                } else {
+                    break;
+                }
+
+                if self.unordered_chunks[p].beginning_fragment || (p == 0) {
+                    break;
+                }
+                p -= 1;
+            }
+            cnt
+        } else {
+            0
+        };
+
+        // next find the set of TSNs that succeeds this chunk
+        let suffix = if new_chunk.ending_fragment {
+            0
+        } else if let Some(mut p) = self
+            .unordered_chunks
+            .iter()
+            .rposition(|f| f.tsn == (new_chunk.tsn + 1))
+        {
+            let mut cnt = 0;
+            let mut tsn = new_chunk.tsn;
+            while p < self.unordered_chunks.len() {
+                if self.unordered_chunks[p].tsn == tsn + 1 {
+                    cnt += self.unordered_chunks[p].user_data.len();
+                    tsn = self.unordered_chunks[p].tsn;
+                } else {
+                    break;
+                }
+
+                if self.unordered_chunks[p].ending_fragment {
+                    break;
+                }
+                p += 1;
+            }
+            cnt
+        } else {
+            0
+        };
+
+        // now sum the lengths together
+        prefix + new_chunk.user_data.len() + suffix
     }
 
     pub(crate) fn find_complete_unordered_chunk_set(&mut self) -> Option<Chunks> {

--- a/src/queue/reassembly_queue.rs
+++ b/src/queue/reassembly_queue.rs
@@ -164,7 +164,7 @@ impl Chunks {
                 //   used by the receiver to reassemble the message.  This means that the
                 //   TSNs for each fragment of a fragmented user message MUST be strictly
                 //   sequential.
-                if c.tsn != last_tsn + 1 {
+                if c.tsn != last_tsn.wrapping_add(1) {
                     // mid or end fragment is missing
                     return false;
                 }
@@ -367,7 +367,7 @@ impl ReassemblyQueue {
             }
 
             // Check if contiguous in TSN
-            if c.tsn != last_tsn + 1 {
+            if c.tsn != last_tsn.wrapping_add(1) {
                 start_idx = -1;
                 continue;
             }


### PR DESCRIPTION
This patch searches the unordered_chunks vector in the reassembly queue to more accurately calculate the size of an incoming message. I wrote it to address an issue where a dropped packet would cause incoming message sizes to be vastly overestimated.

Thank you for any comments!