### PR TITLE
Add Association::is_closing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+  * Add Association::is_closing() to expose SCTP shutdown-in-progress state #51
+
 # 0.10.0
 
   * Report association loss separately from stream finish (breaking) #49

--- a/src/association/association_test.rs
+++ b/src/association/association_test.rs
@@ -18,6 +18,40 @@ fn create_association(config: TransportConfig) -> Association {
 }
 
 #[test]
+fn test_assoc_is_closing() {
+    let closing_states = [
+        AssociationState::ShutdownSent,
+        AssociationState::ShutdownAckSent,
+        AssociationState::ShutdownPending,
+        AssociationState::ShutdownReceived,
+    ];
+
+    for state in [
+        AssociationState::Closed,
+        AssociationState::CookieWait,
+        AssociationState::CookieEchoed,
+        AssociationState::Established,
+    ] {
+        let a = Association {
+            state,
+            ..Default::default()
+        };
+
+        assert!(!a.is_closing(), "{state} should not be closing");
+    }
+
+    for state in closing_states {
+        let a = Association {
+            state,
+            ..Default::default()
+        };
+
+        assert!(a.is_closing(), "{state} should be closing");
+        assert!(!a.is_closed(), "{state} should not be closed");
+    }
+}
+
+#[test]
 fn test_create_forward_tsn_forward_one_abandoned() -> Result<()> {
     let mut a = Association {
         cumulative_tsn_ack_point: 9,

--- a/src/association/mod.rs
+++ b/src/association/mod.rs
@@ -679,6 +679,14 @@ impl Association {
         self.state == AssociationState::Closed
     }
 
+    /// Whether the Association has started SCTP shutdown, but is not closed yet
+    ///
+    /// Closing Associations may still need polling, timer-driven retransmission, and packet output
+    /// before they become fully closed.
+    pub fn is_closing(&self) -> bool {
+        self.state.is_closing()
+    }
+
     /// Whether there is no longer any need to keep the association around
     ///
     /// Closed associations become drained after a brief timeout to absorb any remaining in-flight

--- a/src/association/state.rs
+++ b/src/association/state.rs
@@ -46,7 +46,7 @@ impl fmt::Display for AssociationState {
 }
 
 impl AssociationState {
-    pub(crate) fn is_drained(&self) -> bool {
+    pub(crate) fn is_closing(&self) -> bool {
         matches!(
             *self,
             AssociationState::ShutdownSent
@@ -54,6 +54,10 @@ impl AssociationState {
                 | AssociationState::ShutdownPending
                 | AssociationState::ShutdownReceived
         )
+    }
+
+    pub(crate) fn is_drained(&self) -> bool {
+        self.is_closing()
     }
 }
 


### PR DESCRIPTION
Summary

- Add Association::is_closing() for SCTP shutdown-in-progress states while preserving is_closed() semantics.
- Cover the closing-state mapping with a focused association test.
- Update the unreleased changelog entry.

Closes #51