### PR TITLE
fix: stream reset handshake

### DIFF
--- a/src/association/association_test.rs
+++ b/src/association/association_test.rs
@@ -51,6 +51,139 @@ fn test_assoc_is_closing() {
     }
 }
 
+fn outgoing_reset(rsn: u32, stream_id: StreamId) -> ChunkReconfig {
+    ChunkReconfig {
+        param_a: Some(Box::new(ParamOutgoingResetRequest {
+            reconfig_request_sequence_number: rsn,
+            stream_identifiers: vec![stream_id],
+            ..Default::default()
+        })),
+        ..Default::default()
+    }
+}
+
+#[test]
+fn test_reconfig_in_progress_timeout_does_not_consume_retry_budget() -> Result<()> {
+    let now = Instant::now();
+    let rsn = 7;
+    let mut a = create_association(
+        TransportConfig::default()
+            .with_max_init_retransmits(Some(0))
+            .with_rto_initial_ms(1),
+    );
+
+    a.reconfigs.insert(rsn, outgoing_reset(rsn, 1));
+    a.timers.start(Timer::Reconfig, now, a.rto_mgr.get_rto());
+
+    let response: Box<dyn Param + Send + Sync> = Box::new(ParamReconfigResponse {
+        reconfig_response_sequence_number: rsn,
+        result: ReconfigResult::InProgress,
+    });
+    a.handle_reconfig_param(&response, &mut vec![])?;
+
+    // The outbound path restarts the timer after processing InProgress. RFC
+    // 6525 section 5.2.7 H2 requires the next expiry to retransmit without
+    // incrementing the error counter.
+    a.timers
+        .restart_if_stale(Timer::Reconfig, now, a.rto_mgr.get_rto());
+    let deadline = a.timers.get(Timer::Reconfig).unwrap();
+    a.handle_timeout(deadline);
+
+    assert!(a.reconfigs.contains_key(&rsn));
+    assert!(a.will_retransmit_reconfig);
+    Ok(())
+}
+
+#[test]
+fn test_reset_complete_only_for_successful_reconfig_response() -> Result<()> {
+    let rsn = 7;
+    let stream_id = 1;
+
+    for result in [
+        ReconfigResult::SuccessNop,
+        ReconfigResult::SuccessPerformed,
+        ReconfigResult::Denied,
+        ReconfigResult::ErrorWrongSsn,
+        ReconfigResult::ErrorRequestAlreadyInProgress,
+        ReconfigResult::ErrorBadSequenceNumber,
+        ReconfigResult::InProgress,
+        ReconfigResult::Unknown,
+    ] {
+        let mut a = Association::default();
+        a.pending_reset_completions.push(stream_id);
+        a.reconfigs.insert(rsn, outgoing_reset(rsn, stream_id));
+
+        let response: Box<dyn Param + Send + Sync> = Box::new(ParamReconfigResponse {
+            reconfig_response_sequence_number: rsn,
+            result,
+        });
+        a.handle_reconfig_param(&response, &mut vec![])?;
+
+        let completed = matches!(
+            a.poll(),
+            Some(Event::Stream(StreamEvent::ResetComplete { id })) if id == stream_id
+        );
+        let should_complete = matches!(
+            result,
+            ReconfigResult::SuccessNop | ReconfigResult::SuccessPerformed
+        );
+        assert_eq!(completed, should_complete, "unexpected result for {result}");
+    }
+
+    Ok(())
+}
+
+#[test]
+fn test_reconfig_retransmission_failure_does_not_complete_reset() {
+    let rsn = 7;
+    let stream_id = 1;
+    let mut a = Association::default();
+    a.pending_reset_completions.push(stream_id);
+    a.reconfigs.insert(rsn, outgoing_reset(rsn, stream_id));
+
+    a.on_retransmission_failure(Timer::Reconfig);
+
+    assert!(!matches!(
+        a.poll(),
+        Some(Event::Stream(StreamEvent::ResetComplete { id })) if id == stream_id
+    ));
+}
+
+#[test]
+fn test_reset_complete_preserves_stream_generations() {
+    let stream_id = 1;
+    let mut a = Association::default();
+
+    assert!(
+        a.create_stream(stream_id, false, PayloadProtocolIdentifier::Binary)
+            .is_some()
+    );
+    a.unregister_stream(stream_id, true);
+
+    // Incoming DATA can recreate an id while the previous reciprocal reset is
+    // still pending. A second reset of that id is a distinct generation.
+    assert!(a.get_or_create_stream(stream_id).is_some());
+    a.unregister_stream(stream_id, true);
+
+    a.emit_reset_complete([stream_id]);
+    a.emit_reset_complete([stream_id]);
+
+    let mut finished = 0;
+    let mut reset_complete = 0;
+    while let Some(event) = a.poll() {
+        match event {
+            Event::Stream(StreamEvent::Finished { id }) if id == stream_id => finished += 1,
+            Event::Stream(StreamEvent::ResetComplete { id }) if id == stream_id => {
+                reset_complete += 1;
+            }
+            _ => {}
+        }
+    }
+
+    assert_eq!(finished, 2);
+    assert_eq!(reset_complete, 2);
+}
+
 #[test]
 fn test_create_forward_tsn_forward_one_abandoned() -> Result<()> {
     let mut a = Association {

--- a/src/association/association_test.rs
+++ b/src/association/association_test.rs
@@ -110,7 +110,7 @@ fn test_reset_complete_only_for_successful_reconfig_response() -> Result<()> {
         ReconfigResult::Unknown,
     ] {
         let mut a = Association::default();
-        a.pending_reset_completions.push(stream_id);
+        a.pending_reset_completions.insert(stream_id);
         a.reconfigs.insert(rsn, outgoing_reset(rsn, stream_id));
 
         let response: Box<dyn Param + Send + Sync> = Box::new(ParamReconfigResponse {
@@ -138,7 +138,7 @@ fn test_reconfig_retransmission_failure_does_not_complete_reset() {
     let rsn = 7;
     let stream_id = 1;
     let mut a = Association::default();
-    a.pending_reset_completions.push(stream_id);
+    a.pending_reset_completions.insert(stream_id);
     a.reconfigs.insert(rsn, outgoing_reset(rsn, stream_id));
 
     a.on_retransmission_failure(Timer::Reconfig);

--- a/src/association/mod.rs
+++ b/src/association/mod.rs
@@ -53,7 +53,7 @@ use core::time::Duration;
 use log::{debug, error, trace, warn};
 use rand::random;
 use rustc_hash::FxHashMap;
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::time::Instant;
 use thiserror::Error;
 
@@ -121,6 +121,37 @@ pub enum Event {
     DatagramReceived,
 }
 
+/// Multiset of stream ids owing a [`StreamEvent::ResetComplete`].
+/// Each `Finished` for an id arms one completion, a re-created id is a distinct
+/// generation and owes its own.
+#[derive(Debug, Default)]
+struct PendingResetCompletions(FxHashMap<StreamId, usize>);
+
+impl PendingResetCompletions {
+    /// Arm one completion for this id.
+    fn insert(&mut self, id: StreamId) {
+        *self.0.entry(id).or_default() += 1;
+    }
+
+    fn contains(&self, id: &StreamId) -> bool {
+        self.0.contains_key(id)
+    }
+
+    /// Consume one armed completion for this id.
+    fn take_one(&mut self, id: StreamId) {
+        if let Some(count) = self.0.get_mut(&id) {
+            *count -= 1;
+            if *count == 0 {
+                self.0.remove(&id);
+            }
+        }
+    }
+
+    fn clear(&mut self) {
+        self.0.clear();
+    }
+}
+
 ///Association represents an SCTP association
 //13.2.  Parameters Necessary per Association (i.e., the TCB)
 //Peer : Tag value to be sent in every packet and is received
@@ -170,7 +201,7 @@ pub struct Association {
     max_completed_reconfig_rsn: Option<u32>,
     /// Stream ids for which `StreamEvent::Finished` has fired but whose
     /// `StreamEvent::ResetComplete` is still awaited.
-    pending_reset_completions: HashSet<StreamId>,
+    pending_reset_completions: PendingResetCompletions,
 
     // Non-RFC internal data
     remote_addr: SocketAddr,
@@ -260,7 +291,7 @@ impl Default for Association {
             reconfigs: FxHashMap::default(),
             reconfig_requests: FxHashMap::default(),
             max_completed_reconfig_rsn: None,
-            pending_reset_completions: HashSet::new(),
+            pending_reset_completions: PendingResetCompletions::default(),
 
             // Non-RFC internal data
             remote_addr: SocketAddr::from_str("0.0.0.0:0").unwrap(),
@@ -909,7 +940,7 @@ impl Association {
             if self.pending_reset_completions.contains(&id)
                 && !self.has_pending_reset_for_stream(id)
             {
-                self.pending_reset_completions.remove(&id);
+                self.pending_reset_completions.take_one(id);
                 self.events
                     .push_back(Event::Stream(StreamEvent::ResetComplete { id }));
             }
@@ -1870,6 +1901,7 @@ impl Association {
                     .contains_key(&p.reconfig_response_sequence_number)
                 {
                     self.timers.stop(Timer::Reconfig);
+                    self.timers.suppress_error_count(Timer::Reconfig);
                 }
                 return Ok(());
             }
@@ -1880,7 +1912,20 @@ impl Association {
                     .and_then(|pa| pa.as_any().downcast_ref::<ParamOutgoingResetRequest>())
                     .map(|pa| pa.stream_identifiers.clone())
                     .unwrap_or_default();
-                self.emit_reset_complete(ids);
+                match p.result {
+                    ReconfigResult::SuccessNop | ReconfigResult::SuccessPerformed => {
+                        self.emit_reset_complete(ids);
+                    }
+                    // A denied or failed reset ends the handshake without
+                    // making the id reusable, consume the armed completion
+                    // without notifying.
+                    // (InProgress is intercepted early and can never reach this match)
+                    _ => {
+                        for id in ids {
+                            self.pending_reset_completions.take_one(id);
+                        }
+                    }
+                }
             }
             if self.reconfigs.is_empty() {
                 self.timers.stop(Timer::Reconfig);
@@ -3201,9 +3246,9 @@ impl Association {
                     self.side,
                     self.reconfigs.len()
                 );
-                // Abandonment completes the handshake just like an ack, the
-                // cleared entries no longer block their stream ids, so any
-                // armed id owes its ResetComplete now.
+                // Abandonment ends the handshake without confirmation from the peer,
+                // ids must not be reported as reusable, consume their armed completions
+                // without emitting ResetComplete.
                 let ids: Vec<StreamId> = self
                     .reconfigs
                     .values()
@@ -3215,7 +3260,9 @@ impl Association {
                     .flat_map(|pa| pa.stream_identifiers.iter().copied())
                     .collect();
                 self.reconfigs.clear();
-                self.emit_reset_complete(ids);
+                for id in ids {
+                    self.pending_reset_completions.take_one(id);
+                }
             }
 
             _ => {}

--- a/src/association/mod.rs
+++ b/src/association/mod.rs
@@ -2224,7 +2224,7 @@ impl Association {
 
         // Answer incoming reset requests with the same reset request,
         // this is the peer's teardown of its own half.
-        // 
+        //
         // The reciprocal also keeps each unregistered id pending in
         // `reconfigs`, which is what defers `StreamEvent::ResetComplete`
         // until the reciprocal is acknowledged (handle_reconfig_param) or
@@ -2251,7 +2251,7 @@ impl Association {
 
         // Respond to every request that arrived, fresh, retransmitted
         // or defered by arrival of in-flight data.
-        // 
+        //
         // Intermediate re-evaluations that still fail due to in-flight data
         // stay silent rather than repeating "In progress" on every advance.
         if from_wire || performed {

--- a/src/association/mod.rs
+++ b/src/association/mod.rs
@@ -53,7 +53,7 @@ use core::time::Duration;
 use log::{debug, error, trace, warn};
 use rand::random;
 use rustc_hash::FxHashMap;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::time::Instant;
 use thiserror::Error;
 
@@ -170,7 +170,7 @@ pub struct Association {
     max_completed_reconfig_rsn: Option<u32>,
     /// Stream ids for which `StreamEvent::Finished` has fired but whose
     /// `StreamEvent::ResetComplete` is still awaited.
-    pending_reset_completions: Vec<StreamId>,
+    pending_reset_completions: HashSet<StreamId>,
 
     // Non-RFC internal data
     remote_addr: SocketAddr,
@@ -260,7 +260,7 @@ impl Default for Association {
             reconfigs: FxHashMap::default(),
             reconfig_requests: FxHashMap::default(),
             max_completed_reconfig_rsn: None,
-            pending_reset_completions: Vec::new(),
+            pending_reset_completions: HashSet::new(),
 
             // Non-RFC internal data
             remote_addr: SocketAddr::from_str("0.0.0.0:0").unwrap(),
@@ -909,7 +909,7 @@ impl Association {
             if self.pending_reset_completions.contains(&id)
                 && !self.has_pending_reset_for_stream(id)
             {
-                self.pending_reset_completions.retain(|&x| x != id);
+                self.pending_reset_completions.remove(&id);
                 self.events
                     .push_back(Event::Stream(StreamEvent::ResetComplete { id }));
             }
@@ -939,9 +939,7 @@ impl Association {
                 }));
                 // Every Finished owes a ResetComplete once the handshake
                 // complete, even if the peer re-creates the stream id first.
-                if !self.pending_reset_completions.contains(&stream_identifier) {
-                    self.pending_reset_completions.push(stream_identifier);
-                }
+                self.pending_reset_completions.insert(stream_identifier);
             }
         }
     }

--- a/src/association/mod.rs
+++ b/src/association/mod.rs
@@ -168,6 +168,9 @@ pub struct Association {
     reconfigs: FxHashMap<u32, ChunkReconfig>,
     reconfig_requests: FxHashMap<u32, ParamOutgoingResetRequest>,
     max_completed_reconfig_rsn: Option<u32>,
+    /// Stream ids for which `StreamEvent::Finished` has fired but whose
+    /// `StreamEvent::ResetComplete` is still awaited.
+    pending_reset_completions: Vec<StreamId>,
 
     // Non-RFC internal data
     remote_addr: SocketAddr,
@@ -257,6 +260,7 @@ impl Default for Association {
             reconfigs: FxHashMap::default(),
             reconfig_requests: FxHashMap::default(),
             max_completed_reconfig_rsn: None,
+            pending_reset_completions: Vec::new(),
 
             // Non-RFC internal data
             remote_addr: SocketAddr::from_str("0.0.0.0:0").unwrap(),
@@ -767,6 +771,9 @@ impl Association {
                 self.unregister_stream(si, false);
             }
 
+            // AssociationLost stops any pending  ResetComplete.
+            self.pending_reset_completions.clear();
+
             self.events.push_back(Event::AssociationLost {
                 reason: AssociationError::AssociationClosed,
             });
@@ -892,6 +899,23 @@ impl Association {
         self.set_max_send_message_size(value)
     }
 
+    /// Push [`StreamEvent::ResetComplete`] for each candidate id whose reset
+    /// handshake has completed, `Finished` must have been already fired for it
+    /// and no pending outgoing RE-CONFIG names it.
+    fn emit_reset_complete(&mut self, ids: impl IntoIterator<Item = StreamId>) {
+        for id in ids {
+            // An id with a reset still pending must stay armed,
+            // so only disarm once nothing is pending.
+            if self.pending_reset_completions.contains(&id)
+                && !self.has_pending_reset_for_stream(id)
+            {
+                self.pending_reset_completions.retain(|&x| x != id);
+                self.events
+                    .push_back(Event::Stream(StreamEvent::ResetComplete { id }));
+            }
+        }
+    }
+
     /// Returns true if the given stream ID appears in any pending outgoing
     /// RE-CONFIG that has not yet been acknowledged by the remote peer.
     fn has_pending_reset_for_stream(&self, stream_id: StreamId) -> bool {
@@ -913,6 +937,11 @@ impl Association {
                 self.events.push_back(Event::Stream(StreamEvent::Finished {
                     id: stream_identifier,
                 }));
+                // Every Finished owes a ResetComplete once the handshake
+                // complete, even if the peer re-creates the stream id first.
+                if !self.pending_reset_completions.contains(&stream_identifier) {
+                    self.pending_reset_completions.push(stream_identifier);
+                }
             }
         }
     }
@@ -1834,7 +1863,27 @@ impl Association {
             }
             Ok(())
         } else if let Some(p) = raw.as_any().downcast_ref::<ParamReconfigResponse>() {
-            self.reconfigs.remove(&p.reconfig_response_sequence_number);
+            // In progress result means the peer has deferred the request,
+            // not answered it. The request stays outstanding and its timer restarts
+            // without counting toward the retransmission limit.
+            if p.result == ReconfigResult::InProgress {
+                if self
+                    .reconfigs
+                    .contains_key(&p.reconfig_response_sequence_number)
+                {
+                    self.timers.stop(Timer::Reconfig);
+                }
+                return Ok(());
+            }
+            if let Some(c) = self.reconfigs.remove(&p.reconfig_response_sequence_number) {
+                let ids: Vec<StreamId> = c
+                    .param_a
+                    .as_ref()
+                    .and_then(|pa| pa.as_any().downcast_ref::<ParamOutgoingResetRequest>())
+                    .map(|pa| pa.stream_identifiers.clone())
+                    .unwrap_or_default();
+                self.emit_reset_complete(ids);
+            }
             if self.reconfigs.is_empty() {
                 self.timers.stop(Timer::Reconfig);
             }
@@ -2145,22 +2194,21 @@ impl Association {
     fn reset_streams_if_any(
         &mut self,
         p: &ParamOutgoingResetRequest,
-        respond: bool,
+        from_wire: bool,
         reply: &mut Vec<Packet>,
     ) -> Result<()> {
         let mut result = ReconfigResult::SuccessPerformed;
         let mut sis_to_reset = vec![];
 
-        if sna32lte(p.sender_last_tsn, self.peer_last_tsn) {
+        let performed = sna32lte(p.sender_last_tsn, self.peer_last_tsn);
+        if performed {
             debug!(
                 "[{}] resetStream(): senderLastTSN={} <= peer_last_tsn={}",
                 self.side, p.sender_last_tsn, self.peer_last_tsn
             );
             for id in &p.stream_identifiers {
                 if self.streams.contains_key(id) {
-                    if respond {
-                        sis_to_reset.push(*id);
-                    }
+                    sis_to_reset.push(*id);
                     self.unregister_stream(*id, true);
                 }
             }
@@ -2174,8 +2222,13 @@ impl Association {
             result = ReconfigResult::InProgress;
         }
 
-        // Answer incoming reset requests with the same reset request, but with
-        // reconfig_response_sequence_number.
+        // Answer incoming reset requests with the same reset request,
+        // this is the peer's teardown of its own half.
+        // 
+        // The reciprocal also keeps each unregistered id pending in
+        // `reconfigs`, which is what defers `StreamEvent::ResetComplete`
+        // until the reciprocal is acknowledged (handle_reconfig_param) or
+        // abandoned (on_retransmission_failure).
         if !sis_to_reset.is_empty() {
             let rsn = self.generate_next_rsn();
             let tsn = self.my_next_tsn - 1;
@@ -2196,17 +2249,24 @@ impl Association {
             reply.push(p);
         }
 
-        let packet = self.create_packet(vec![Box::new(ChunkReconfig {
-            param_a: Some(Box::new(ParamReconfigResponse {
-                reconfig_response_sequence_number: p.reconfig_request_sequence_number,
-                result,
-            })),
-            param_b: None,
-        })]);
+        // Respond to every request that arrived, fresh, retransmitted
+        // or defered by arrival of in-flight data.
+        // 
+        // Intermediate re-evaluations that still fail due to in-flight data
+        // stay silent rather than repeating "In progress" on every advance.
+        if from_wire || performed {
+            let packet = self.create_packet(vec![Box::new(ChunkReconfig {
+                param_a: Some(Box::new(ParamReconfigResponse {
+                    reconfig_response_sequence_number: p.reconfig_request_sequence_number,
+                    result,
+                })),
+                param_b: None,
+            })]);
 
-        debug!("[{}] RESET RESPONSE: {}", self.side, packet);
+            debug!("[{}] RESET RESPONSE: {}", self.side, packet);
 
-        reply.push(packet);
+            reply.push(packet);
+        }
 
         Ok(())
     }
@@ -3143,7 +3203,21 @@ impl Association {
                     self.side,
                     self.reconfigs.len()
                 );
+                // Abandonment completes the handshake just like an ack, the
+                // cleared entries no longer block their stream ids, so any
+                // armed id owes its ResetComplete now.
+                let ids: Vec<StreamId> = self
+                    .reconfigs
+                    .values()
+                    .filter_map(|c| {
+                        c.param_a
+                            .as_ref()
+                            .and_then(|pa| pa.as_any().downcast_ref::<ParamOutgoingResetRequest>())
+                    })
+                    .flat_map(|pa| pa.stream_identifiers.iter().copied())
+                    .collect();
                 self.reconfigs.clear();
+                self.emit_reset_complete(ids);
             }
 
             _ => {}

--- a/src/association/stream.rs
+++ b/src/association/stream.rs
@@ -36,9 +36,23 @@ pub enum StreamEvent {
         /// Which stream is now writable
         id: StreamId,
     },
-    /// A finished stream has been fully acknowledged or stopped
+    /// The stream was torn down by a reset, an inbound reset
+    /// request from the peer naming the id was processed or
+    /// its reciprocal to a locally-initiated one.
+    ///
+    /// No more data can be read from or written to it.
+    ///
+    /// Once this fires, [`StreamEvent::ResetComplete`] for the same id is
+    /// guaranteed to eventually follow, unless the association closes first.
     Finished {
         /// Which stream has been finished
+        id: StreamId,
+    },
+    /// The reset handshake involving this stream id has fully
+    /// completed and the id can be reused and
+    /// `[Association::open_stream]` stop failing.
+    ResetComplete {
+        /// Which stream id has become reusable
         id: StreamId,
     },
     /// The peer asked us to stop sending on an outgoing stream
@@ -229,20 +243,32 @@ impl<'a> Stream<'a> {
 
     /// stop closes the read-direction of the stream.
     /// Future calls to read are not permitted after calling stop.
+    ///    
+    /// NOTE: a stream closed without a queued reset never produces
+    /// `StreamEvent::Finished` / `StreamEvent::ResetComplete`.
     pub fn stop(&mut self) -> Result<()> {
-        let mut reset = false;
-        if let Some(s) = self.association.streams.get_mut(&self.stream_identifier) {
-            if s.state == RecvSendState::Readable || s.state == RecvSendState::ReadWritable {
-                reset = true;
-            }
-            s.state = ((s.state as u8) & 0x2).into();
-        }
+        let reset = self
+            .association
+            .streams
+            .get(&self.stream_identifier)
+            .is_some_and(|s| {
+                s.state == RecvSendState::Readable || s.state == RecvSendState::ReadWritable
+            });
 
         if reset {
             // Reset the outgoing stream
             // https://tools.ietf.org/html/rfc6525
+            //
+            // Queued before clearing the read bit below, send_reset_request
+            // is the only fallible step, and failing after the state
+            // mutation would leave the stream half-closed with the reset
+            // silently dropped and unretryable.
             self.association
                 .send_reset_request(self.stream_identifier)?;
+        }
+
+        if let Some(s) = self.association.streams.get_mut(&self.stream_identifier) {
+            s.state = ((s.state as u8) & 0x2).into();
         }
 
         Ok(())
@@ -261,6 +287,10 @@ impl<'a> Stream<'a> {
     ///
     /// This is a convenience method that calls `finish()` followed by `stop()`.
     /// Resets the stream when both halves are shutdown.
+    ///
+    /// The single failure mode is `stop()`'s, if the association is not
+    /// established, no reset was queued, retrying `close()` will
+    /// attempt the reset again.
     pub fn close(&mut self) -> Result<()> {
         self.finish()?;
         self.stop()

--- a/src/association/timer.rs
+++ b/src/association/timer.rs
@@ -34,6 +34,8 @@ pub(crate) struct TimerTable {
     retrans: [usize; TIMER_COUNT],
     /// Maximum retransmissions for each timer. `None` means unlimited.
     max_retrans: [Option<usize>; TIMER_COUNT],
+    /// Timers whose next expiry must not increment the error counter
+    no_error_count: [bool; TIMER_COUNT],
     /// Maximum RTO value for exponential backoff.
     rto_max: u64,
 }
@@ -44,6 +46,7 @@ impl Default for TimerTable {
             data: [None; TIMER_COUNT],
             retrans: [0; TIMER_COUNT],
             max_retrans: [None; TIMER_COUNT],
+            no_error_count: [false; TIMER_COUNT],
             rto_max: 60000, // Default RTO_MAX
         }
     }
@@ -106,19 +109,29 @@ impl TimerTable {
     pub fn stop(&mut self, timer: Timer) {
         self.data[timer as usize] = None;
         self.retrans[timer as usize] = 0;
+        self.no_error_count[timer as usize] = false;
+    }
+
+    /// Exempt the timer's next expiry from the `max_retrans` accounting.
+    pub fn suppress_error_count(&mut self, timer: Timer) {
+        self.no_error_count[timer as usize] = true;
     }
 
     pub fn is_expired(&mut self, timer: Timer, after: Instant) -> (bool, bool, usize) {
         let expired = self.data[timer as usize].is_some_and(|x| x <= after);
         let mut failure = false;
         if expired {
-            self.retrans[timer as usize] += 1;
-            if let Some(max) = self.max_retrans[timer as usize] {
-                if self.retrans[timer as usize] > max {
-                    failure = true;
+            if self.no_error_count[timer as usize] {
+                self.no_error_count[timer as usize] = false;
+            } else {
+                self.retrans[timer as usize] += 1;
+                if let Some(max) = self.max_retrans[timer as usize] {
+                    if self.retrans[timer as usize] > max {
+                        failure = true;
+                    }
                 }
+                // If max_retrans is None, failure stays false (unlimited)
             }
-            // If max_retrans is None, failure stays false (unlimited)
         }
 
         (expired, failure, self.retrans[timer as usize])


### PR DESCRIPTION
The following commit fixes how the peer was reacting to a Reset request. Now it behaves correctly and:

- reset_streams_if_any now queues the reciprocal reset correctly
- In Progress responses are now sent only when needed, no wasted idempotent messages
- a new event ResetComplete is emitted once the reset handshake completes, allowing open_stream to be called on the same id without failures