### PR TITLE
Fix stream reset completion and request serialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Unreleased
 
-  * Fix reset completion bookkeeping across failed and overlapping resets #54
+  * Fix stream reset completion, failure reporting, and request serialization #54
 
 # 0.10.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+  * Fix reset completion bookkeeping across failed and overlapping resets #54
+
 # 0.10.2
 
   * Calculate message length accurately in the reassembly queue #50

--- a/src/association/association_test.rs
+++ b/src/association/association_test.rs
@@ -1545,6 +1545,35 @@ fn test_forward_tsn_skip_is_scoped_to_queued_reset_generation() -> Result<()> {
 }
 
 #[test]
+fn test_retransmitted_forward_tsn_stays_with_reset_generation() -> Result<()> {
+    let mut a = association_with_queued_second_reset()?;
+
+    // The first FORWARD-TSN advances through generation B's abandoned SSN 0
+    // and lets its pending reset complete.
+    a.handle_forward_tsn(&ChunkForwardTsn {
+        new_cumulative_tsn: 2,
+        streams: vec![ChunkForwardTsnStream {
+            identifier: 1,
+            sequence: 0,
+        }],
+    })?;
+    assert!(!a.reconfig_requests.contains_key(&8));
+
+    // If the resulting SACK is lost, the sender can legitimately repeat the
+    // same stream skip while advancing over an unrelated abandoned TSN. The
+    // repeated entry still belongs to generation B, not the future tail.
+    a.handle_forward_tsn(&ChunkForwardTsn {
+        new_cumulative_tsn: 3,
+        streams: vec![ChunkForwardTsnStream {
+            identifier: 1,
+            sequence: 0,
+        }],
+    })?;
+
+    assert_generation_c_ssn_zero_is_readable(a)
+}
+
+#[test]
 fn test_i_forward_tsn_skip_is_scoped_to_queued_reset_generation() -> Result<()> {
     let mut a = association_with_queued_second_reset()?;
     a.handle_i_forward_tsn(&ChunkIForwardTsn {
@@ -1655,6 +1684,36 @@ fn test_forward_tsn_preserves_complete_deferred_message() -> Result<()> {
             sequence: 1,
         }],
     })?;
+    assert_received_message_survives_forward_tsn(a)
+}
+
+#[test]
+fn test_forward_tsn_preserves_out_of_order_complete_deferred_message() -> Result<()> {
+    let mut a = association_with_retiring_boundary_data()?;
+
+    // Generation B's complete SSN 0 arrives above a TSN gap, so it remains in
+    // both the association payload queue and the reset-generation holding map.
+    a.handle_data(&ChunkPayloadData {
+        tsn: 3,
+        stream_identifier: 1,
+        stream_sequence_number: 0,
+        beginning_fragment: true,
+        ending_fragment: true,
+        user_data: Bytes::from_static(b"received"),
+        ..Default::default()
+    })?;
+
+    // The sender may not have received the gap SACK before abandoning TSNs 2
+    // and 3. Advancing the cumulative TSN must not erase a complete message
+    // that this receiver already holds for the successor generation.
+    a.handle_forward_tsn(&ChunkForwardTsn {
+        new_cumulative_tsn: 3,
+        streams: vec![ChunkForwardTsnStream {
+            identifier: 1,
+            sequence: 0,
+        }],
+    })?;
+
     assert_received_message_survives_forward_tsn(a)
 }
 
@@ -1775,6 +1834,26 @@ fn test_stop_discards_unread_retiring_data_and_unblocks_finished() -> Result<()>
         a.poll(),
         Some(Event::Stream(StreamEvent::Finished { id: 1 }))
     ));
+    Ok(())
+}
+
+#[test]
+fn test_stop_during_retirement_does_not_queue_duplicate_reset() -> Result<()> {
+    let mut a = association_with_retiring_boundary_data()?;
+    assert_eq!(
+        a.reconfigs.len(),
+        1,
+        "peer reset should queue one reciprocal"
+    );
+    assert!(a.pending_reset_streams.is_empty());
+
+    a.stream(1)?.stop()?;
+
+    assert!(
+        a.pending_reset_streams.is_empty(),
+        "the reciprocal already resets this outgoing stream"
+    );
+    assert_eq!(a.reconfigs.len(), 1);
     Ok(())
 }
 

--- a/src/association/association_test.rs
+++ b/src/association/association_test.rs
@@ -2028,6 +2028,46 @@ fn test_successor_forward_tsn_releases_covered_message_before_lost_tail() -> Res
 }
 
 #[test]
+fn test_resolved_successor_prefix_releases_message_before_stale_tail() -> Result<()> {
+    let mut a = association_with_queued_second_reset()?;
+    a.handle_forward_tsn(&ChunkForwardTsn {
+        new_cumulative_tsn: 2,
+        streams: vec![ChunkForwardTsnStream {
+            identifier: 1,
+            sequence: 2,
+        }],
+    })?;
+    a.handle_forward_tsn(&ChunkForwardTsn {
+        new_cumulative_tsn: 3,
+        streams: vec![ChunkForwardTsnStream {
+            identifier: 1,
+            sequence: 2,
+        }],
+    })?;
+    a.handle_data(&ChunkPayloadData {
+        tsn: 4,
+        stream_identifier: 1,
+        stream_sequence_number: 1,
+        beginning_fragment: true,
+        ending_fragment: true,
+        user_data: Bytes::from_static(b"one"),
+        ..Default::default()
+    })?;
+
+    let old = a.stream(1)?.read()?.unwrap();
+    let mut payload = [0; 3];
+    assert_eq!(old.read(&mut payload)?, payload.len());
+    let one = a
+        .stream(1)?
+        .read()?
+        .expect("resolved successor data must not wait for the stale old tail");
+    let mut payload = [0; 3];
+    assert_eq!(one.read(&mut payload)?, payload.len());
+    assert_eq!(&payload, b"one");
+    Ok(())
+}
+
+#[test]
 fn test_i_forward_tsn_skip_is_scoped_to_queued_reset_generation() -> Result<()> {
     let mut a = association_with_queued_second_reset()?;
     a.handle_i_forward_tsn(&ChunkIForwardTsn {

--- a/src/association/association_test.rs
+++ b/src/association/association_test.rs
@@ -2050,7 +2050,7 @@ fn test_deferred_bounded_ordered_forward_tsn_updates_are_coalesced() -> Result<(
     );
     assert!(matches!(
         ordered[0].kind,
-        DeferredForwardTsnKind::Ordered { last_ssn: 7 }
+        DeferredForwardTsnKind::Ordered { last_ssn: 7, .. }
     ));
     Ok(())
 }

--- a/src/association/association_test.rs
+++ b/src/association/association_test.rs
@@ -1884,6 +1884,50 @@ fn test_reordered_successor_waits_before_consuming_repeated_old_forward_tsn() ->
 }
 
 #[test]
+fn test_successor_forward_tsn_releases_covered_out_of_order_message() -> Result<()> {
+    let mut a = association_with_queued_second_reset()?;
+    a.handle_forward_tsn(&ChunkForwardTsn {
+        new_cumulative_tsn: 2,
+        streams: vec![ChunkForwardTsnStream {
+            identifier: 1,
+            sequence: 0,
+        }],
+    })?;
+    a.handle_data(&ChunkPayloadData {
+        tsn: 5,
+        stream_identifier: 1,
+        stream_sequence_number: 1,
+        beginning_fragment: true,
+        ending_fragment: true,
+        user_data: Bytes::from_static(b"one"),
+        ..Default::default()
+    })?;
+
+    // The sender did not receive the gap acknowledgement for TSN 5 and
+    // abandons both missing SSN 0 and the already-complete SSN 1.
+    a.handle_forward_tsn(&ChunkForwardTsn {
+        new_cumulative_tsn: 5,
+        streams: vec![ChunkForwardTsnStream {
+            identifier: 1,
+            sequence: 1,
+        }],
+    })?;
+
+    let old = a.stream(1)?.read()?.unwrap();
+    let mut payload = [0; 3];
+    assert_eq!(old.read(&mut payload)?, payload.len());
+
+    let successor = a
+        .stream(1)?
+        .read()?
+        .expect("the successor skip must release the complete covered message");
+    let mut payload = [0; 3];
+    assert_eq!(successor.read(&mut payload)?, payload.len());
+    assert_eq!(&payload, b"one");
+    Ok(())
+}
+
+#[test]
 fn test_i_forward_tsn_skip_is_scoped_to_queued_reset_generation() -> Result<()> {
     let mut a = association_with_queued_second_reset()?;
     a.handle_i_forward_tsn(&ChunkIForwardTsn {

--- a/src/association/association_test.rs
+++ b/src/association/association_test.rs
@@ -553,6 +553,97 @@ fn test_outgoing_reset_does_not_ack_unsent_reciprocal_with_unrelated_timer() -> 
 }
 
 #[test]
+fn test_failed_generation_stays_quarantined_after_other_success() -> Result<()> {
+    let stream_id = 1;
+    let mut a = Association::default();
+
+    a.pending_reset_completions.insert(stream_id);
+    a.pending_reset_completions.insert(stream_id);
+    a.reconfigs.insert(7, outgoing_reset(7, stream_id));
+    a.reconfigs.insert(8, outgoing_reset(8, stream_id));
+
+    // The older generation completes, but the newer generation is denied.
+    // A success for the former cannot make the latter safe to reuse.
+    for (rsn, result) in [
+        (7, ReconfigResult::SuccessPerformed),
+        (8, ReconfigResult::Denied),
+    ] {
+        let response: Box<dyn Param + Send + Sync> = Box::new(ParamReconfigResponse {
+            reconfig_response_sequence_number: rsn,
+            result,
+        });
+        a.handle_reconfig_param(&response, &mut vec![])?;
+    }
+
+    assert!(matches!(
+        a.open_stream(stream_id, PayloadProtocolIdentifier::Binary),
+        Err(Error::ErrStreamResetPending)
+    ));
+    Ok(())
+}
+
+#[test]
+fn test_second_reconfig_request_stays_buffered_while_timer_runs() -> Result<()> {
+    let stream_id = 1;
+    let sent_rsn = 99;
+    let mut a = Association {
+        state: AssociationState::Established,
+        my_next_tsn: 1,
+        ..Default::default()
+    };
+    assert!(
+        a.create_stream(stream_id, false, PayloadProtocolIdentifier::Binary)
+            .is_some()
+    );
+
+    a.reconfigs.insert(sent_rsn, outgoing_reset(sent_rsn, 2));
+    a.timers
+        .start(Timer::Reconfig, Instant::now(), a.rto_mgr.get_rto());
+
+    // Processing the peer's request creates a reciprocal request while another
+    // local request is already in flight. RFC 6525 section 5.1.1 requires the
+    // reciprocal request to remain buffered until the running timer stops.
+    let request: Box<dyn Param + Send + Sync> = Box::new(ParamOutgoingResetRequest {
+        reconfig_request_sequence_number: 7,
+        reconfig_response_sequence_number: u32::MAX,
+        sender_last_tsn: a.peer_last_tsn,
+        stream_identifiers: vec![stream_id],
+    });
+    let mut reply = vec![];
+    a.handle_reconfig_param(&request, &mut reply)?;
+
+    let reciprocal_rsn = *a.reconfigs.keys().find(|&&rsn| rsn != sent_rsn).unwrap();
+    assert!(a.unsent_reconfigs.contains(&reciprocal_rsn));
+    a.control_queue.extend(reply);
+
+    assert!(a.poll_transmit(Instant::now()).is_some());
+    assert!(
+        a.unsent_reconfigs.contains(&reciprocal_rsn),
+        "a second request must remain buffered while the first request's timer runs"
+    );
+    Ok(())
+}
+
+#[test]
+fn test_peer_recreated_quarantined_stream_is_not_writable() -> Result<()> {
+    let stream_id = 1;
+    let mut a = Association::default();
+
+    // The peer may start its new incoming generation before our reciprocal
+    // outgoing reset is acknowledged. Reading that generation is safe, but
+    // sending with a freshly initialized SSN is not yet safe.
+    a.pending_reset_completions.insert(stream_id);
+    a.reconfigs.insert(7, outgoing_reset(7, stream_id));
+
+    assert!(a.get_or_create_stream(stream_id).is_some());
+    assert!(
+        !a.stream(stream_id)?.is_writable(),
+        "a pending reciprocal reset must quarantine the outgoing direction"
+    );
+    Ok(())
+}
+
+#[test]
 fn test_create_forward_tsn_forward_one_abandoned() -> Result<()> {
     let mut a = Association {
         cumulative_tsn_ack_point: 9,

--- a/src/association/association_test.rs
+++ b/src/association/association_test.rs
@@ -2067,6 +2067,164 @@ fn test_resolved_successor_prefix_releases_message_before_stale_tail() -> Result
     Ok(())
 }
 
+fn assert_covered_partial_after_unaffected_anchor_is_discarded(last_ssn: u16) -> Result<()> {
+    let mut a = association_with_queued_second_reset()?;
+    for new_cumulative_tsn in [2, 3] {
+        a.handle_forward_tsn(&ChunkForwardTsn {
+            new_cumulative_tsn,
+            streams: vec![ChunkForwardTsnStream {
+                identifier: 1,
+                sequence: last_ssn,
+            }],
+        })?;
+    }
+    for chunk in [
+        ChunkPayloadData {
+            tsn: 4,
+            stream_identifier: 1,
+            stream_sequence_number: 1,
+            beginning_fragment: false,
+            ending_fragment: true,
+            user_data: Bytes::from_static(b"orphan"),
+            ..Default::default()
+        },
+        ChunkPayloadData {
+            tsn: 5,
+            stream_identifier: 1,
+            stream_sequence_number: 0,
+            beginning_fragment: true,
+            ending_fragment: true,
+            user_data: Bytes::from_static(b"zero"),
+            ..Default::default()
+        },
+    ] {
+        a.handle_data(&chunk)?;
+    }
+
+    let old = a.stream(1)?.read()?.unwrap();
+    let mut payload = [0; 3];
+    assert_eq!(old.read(&mut payload)?, payload.len());
+    let zero = a.stream(1)?.read()?.unwrap();
+    let mut payload = [0; 4];
+    assert_eq!(zero.read(&mut payload)?, payload.len());
+    assert_eq!(&payload, b"zero");
+    assert_eq!(
+        a.get_my_receiver_window_credit(),
+        a.max_receive_buffer_size,
+        "the covered partial message must release its receive-window credit"
+    );
+    Ok(())
+}
+
+#[test]
+fn test_full_forward_update_discards_covered_partial_after_anchor() -> Result<()> {
+    assert_covered_partial_after_unaffected_anchor_is_discarded(1)
+}
+
+#[test]
+fn test_partial_forward_update_discards_covered_partial_after_anchor() -> Result<()> {
+    assert_covered_partial_after_unaffected_anchor_is_discarded(2)
+}
+
+#[test]
+fn test_drained_generation_discards_retained_forward_suffix() -> Result<()> {
+    let mut a = association_with_retiring_boundary_data()?;
+    let reset: Box<dyn Param + Send + Sync> = Box::new(ParamOutgoingResetRequest {
+        reconfig_request_sequence_number: 8,
+        reconfig_response_sequence_number: u32::MAX,
+        sender_last_tsn: 5,
+        stream_identifiers: vec![1],
+    });
+    a.handle_reconfig_param(&reset, &mut vec![])?;
+    a.handle_data(&ChunkPayloadData {
+        tsn: 4,
+        stream_identifier: 1,
+        stream_sequence_number: 1,
+        beginning_fragment: true,
+        ending_fragment: true,
+        user_data: Bytes::from_static(b"one"),
+        ..Default::default()
+    })?;
+    a.handle_forward_tsn(&ChunkForwardTsn {
+        new_cumulative_tsn: 5,
+        streams: vec![ChunkForwardTsnStream {
+            identifier: 1,
+            sequence: 2,
+        }],
+    })?;
+
+    let old = a.stream(1)?.read()?.unwrap();
+    let mut payload = [0; 3];
+    assert_eq!(old.read(&mut payload)?, payload.len());
+    let one = a.stream(1)?.read()?.unwrap();
+    let mut payload = [0; 3];
+    assert_eq!(one.read(&mut payload)?, payload.len());
+    assert_eq!(&payload, b"one");
+    assert!(
+        a.deferred_forward_tsns.get(&1).is_none_or(|updates| {
+            updates
+                .iter()
+                .all(|update| update.generation_boundary != Some(5))
+        }),
+        "a drained reset generation must discard its retained ambiguous suffix"
+    );
+    Ok(())
+}
+
+#[test]
+fn test_first_reset_discards_retained_tail_forward_suffix() -> Result<()> {
+    let mut a = association_with_queued_second_reset()?;
+    a.handle_forward_tsn(&ChunkForwardTsn {
+        new_cumulative_tsn: 2,
+        streams: vec![ChunkForwardTsnStream {
+            identifier: 1,
+            sequence: 0,
+        }],
+    })?;
+    a.handle_data(&ChunkPayloadData {
+        tsn: 4,
+        stream_identifier: 1,
+        stream_sequence_number: 1,
+        beginning_fragment: true,
+        ending_fragment: true,
+        user_data: Bytes::from_static(b"one"),
+        ..Default::default()
+    })?;
+    a.handle_forward_tsn(&ChunkForwardTsn {
+        new_cumulative_tsn: 5,
+        streams: vec![ChunkForwardTsnStream {
+            identifier: 1,
+            sequence: 2,
+        }],
+    })?;
+
+    let old = a.stream(1)?.read()?.unwrap();
+    let mut payload = [0; 3];
+    assert_eq!(old.read(&mut payload)?, payload.len());
+    let one = a.stream(1)?.read()?.unwrap();
+    let mut payload = [0; 3];
+    assert_eq!(one.read(&mut payload)?, payload.len());
+    assert_eq!(&payload, b"one");
+    assert!(
+        a.deferred_forward_tsns[&1]
+            .iter()
+            .any(|update| update.generation_boundary.is_none())
+    );
+
+    let reset: Box<dyn Param + Send + Sync> = Box::new(ParamOutgoingResetRequest {
+        reconfig_request_sequence_number: 9,
+        reconfig_response_sequence_number: u32::MAX,
+        sender_last_tsn: 5,
+        stream_identifiers: vec![1],
+    });
+    a.handle_reconfig_param(&reset, &mut vec![])?;
+    assert!(
+        !a.deferred_forward_tsns.contains_key(&1),
+        "resetting a drained tail must discard its retained ambiguous suffix"
+    );
+    Ok(())
+}
+
 #[test]
 fn test_i_forward_tsn_skip_is_scoped_to_queued_reset_generation() -> Result<()> {
     let mut a = association_with_queued_second_reset()?;

--- a/src/association/association_test.rs
+++ b/src/association/association_test.rs
@@ -1928,6 +1928,63 @@ fn test_successor_forward_tsn_releases_covered_out_of_order_message() -> Result<
 }
 
 #[test]
+fn test_cross_generation_forward_tsn_does_not_skip_uncovered_successor_ssn() -> Result<()> {
+    let mut a = association_with_queued_second_reset()?;
+    a.handle_forward_tsn(&ChunkForwardTsn {
+        new_cumulative_tsn: 2,
+        streams: vec![ChunkForwardTsnStream {
+            identifier: 1,
+            sequence: 1,
+        }],
+    })?;
+    a.handle_data(&ChunkPayloadData {
+        tsn: 4,
+        stream_identifier: 1,
+        stream_sequence_number: 0,
+        beginning_fragment: true,
+        ending_fragment: true,
+        user_data: Bytes::from_static(b"zero"),
+        ..Default::default()
+    })?;
+
+    // A lost SACK can make one FORWARD-TSN span old SSN 1 and successor SSN
+    // 0. The old maximum SSN must not also skip successor SSN 1.
+    a.handle_forward_tsn(&ChunkForwardTsn {
+        new_cumulative_tsn: 4,
+        streams: vec![ChunkForwardTsnStream {
+            identifier: 1,
+            sequence: 1,
+        }],
+    })?;
+
+    let old = a.stream(1)?.read()?.unwrap();
+    let mut payload = [0; 3];
+    assert_eq!(old.read(&mut payload)?, payload.len());
+    let zero = a.stream(1)?.read()?.unwrap();
+    let mut payload = [0; 4];
+    assert_eq!(zero.read(&mut payload)?, payload.len());
+    assert_eq!(&payload, b"zero");
+
+    a.handle_data(&ChunkPayloadData {
+        tsn: 5,
+        stream_identifier: 1,
+        stream_sequence_number: 1,
+        beginning_fragment: true,
+        ending_fragment: true,
+        user_data: Bytes::from_static(b"one"),
+        ..Default::default()
+    })?;
+    let one = a
+        .stream(1)?
+        .read()?
+        .expect("the successor SSN outside the covered TSN range must remain live");
+    let mut payload = [0; 3];
+    assert_eq!(one.read(&mut payload)?, payload.len());
+    assert_eq!(&payload, b"one");
+    Ok(())
+}
+
+#[test]
 fn test_i_forward_tsn_skip_is_scoped_to_queued_reset_generation() -> Result<()> {
     let mut a = association_with_queued_second_reset()?;
     a.handle_i_forward_tsn(&ChunkIForwardTsn {

--- a/src/association/association_test.rs
+++ b/src/association/association_test.rs
@@ -868,6 +868,46 @@ fn test_local_reset_does_not_overtake_pending_data() -> Result<()> {
 }
 
 #[test]
+fn test_local_reset_is_not_blocked_by_unrelated_pending_data() -> Result<()> {
+    let reset_stream_id = 1;
+    let unrelated_stream_id = 2;
+    let mut a = Association {
+        state: AssociationState::Established,
+        my_next_tsn: 2,
+        cwnd: 0,
+        rwnd: 0,
+        mtu: 1400,
+        ..Default::default()
+    };
+    a.inflight_queue.push_no_check(ChunkPayloadData {
+        tsn: 1,
+        stream_identifier: unrelated_stream_id,
+        user_data: Bytes::from_static(b"inflight"),
+        ..Default::default()
+    });
+    a.pending_queue.push(ChunkPayloadData {
+        stream_identifier: unrelated_stream_id,
+        beginning_fragment: true,
+        ending_fragment: true,
+        user_data: Bytes::from_static(b"flow controlled"),
+        ..Default::default()
+    });
+    a.send_reset_request(reset_stream_id)?;
+
+    let _ = a.gather_outbound(Instant::now());
+
+    assert!(
+        a.active_reconfig.is_some(),
+        "flow-controlled DATA on another stream must not starve this reset"
+    );
+    assert!(
+        !a.pending_queue.is_empty(),
+        "the test requires the unrelated DATA to remain flow controlled"
+    );
+    Ok(())
+}
+
+#[test]
 fn test_reset_sender_last_tsn_wraps_at_zero() -> Result<()> {
     let stream_id = 1;
     let mut a = Association {

--- a/src/association/association_test.rs
+++ b/src/association/association_test.rs
@@ -150,6 +150,30 @@ fn test_reconfig_retransmission_failure_does_not_complete_reset() {
 }
 
 #[test]
+fn test_denied_reset_remains_quarantined_without_terminal_event() -> Result<()> {
+    let rsn = 7;
+    let stream_id = 1;
+    let mut a = Association::default();
+    a.pending_reset_completions.insert(stream_id);
+    a.reconfigs.insert(rsn, outgoing_reset(rsn, stream_id));
+
+    let response: Box<dyn Param + Send + Sync> = Box::new(ParamReconfigResponse {
+        reconfig_response_sequence_number: rsn,
+        result: ReconfigResult::Denied,
+    });
+    a.handle_reconfig_param(&response, &mut vec![])?;
+
+    // Until the public API has a ResetFailed/ResetDenied event, forgetting
+    // this generation would leave the caller unable to distinguish an unsafe
+    // ID from one whose reset completed.
+    assert!(
+        a.pending_reset_completions.contains(&stream_id),
+        "a failed reset needs either a terminal event or continued quarantine"
+    );
+    Ok(())
+}
+
+#[test]
 fn test_reset_complete_preserves_stream_generations() {
     let stream_id = 1;
     let mut a = Association::default();
@@ -182,6 +206,78 @@ fn test_reset_complete_preserves_stream_generations() {
 
     assert_eq!(finished, 2);
     assert_eq!(reset_complete, 2);
+}
+
+#[test]
+fn test_reset_complete_preserves_generations_through_responses() -> Result<()> {
+    let stream_id = 1;
+    let first_rsn = 7;
+    let second_rsn = 8;
+    let mut a = Association::default();
+
+    // Two Finished events for the same stream ID represent two distinct
+    // incarnations. Each successful reset response must complete one.
+    a.pending_reset_completions.insert(stream_id);
+    a.pending_reset_completions.insert(stream_id);
+    a.reconfigs
+        .insert(first_rsn, outgoing_reset(first_rsn, stream_id));
+    a.reconfigs
+        .insert(second_rsn, outgoing_reset(second_rsn, stream_id));
+
+    for rsn in [first_rsn, second_rsn] {
+        let response: Box<dyn Param + Send + Sync> = Box::new(ParamReconfigResponse {
+            reconfig_response_sequence_number: rsn,
+            result: ReconfigResult::SuccessPerformed,
+        });
+        a.handle_reconfig_param(&response, &mut vec![])?;
+    }
+
+    let reset_complete = std::iter::from_fn(|| a.poll())
+        .filter(|event| {
+            matches!(
+                event,
+                Event::Stream(StreamEvent::ResetComplete { id }) if *id == stream_id
+            )
+        })
+        .count();
+
+    assert_eq!(
+        reset_complete, 2,
+        "each completed stream generation needs its own ResetComplete"
+    );
+    Ok(())
+}
+
+#[test]
+fn test_outgoing_reset_implicitly_acknowledges_pending_request() -> Result<()> {
+    let local_rsn = 7;
+    let stream_id = 1;
+    let mut a = Association::default();
+
+    a.reconfigs
+        .insert(local_rsn, outgoing_reset(local_rsn, stream_id));
+    a.timers
+        .start(Timer::Reconfig, Instant::now(), a.rto_mgr.get_rto());
+
+    // RFC 6525 section 5.2.2 E1: the response sequence number carried by an
+    // incoming Outgoing Reset Request acknowledges our matching request.
+    let request: Box<dyn Param + Send + Sync> = Box::new(ParamOutgoingResetRequest {
+        reconfig_request_sequence_number: 8,
+        reconfig_response_sequence_number: local_rsn,
+        sender_last_tsn: a.peer_last_tsn,
+        stream_identifiers: vec![],
+    });
+    a.handle_reconfig_param(&request, &mut vec![])?;
+
+    assert!(
+        !a.reconfigs.contains_key(&local_rsn),
+        "the implicitly acknowledged request must no longer be in flight"
+    );
+    assert!(
+        a.timers.get(Timer::Reconfig).is_none(),
+        "the timer must stop after the final in-flight request is acknowledged"
+    );
+    Ok(())
 }
 
 #[test]

--- a/src/association/association_test.rs
+++ b/src/association/association_test.rs
@@ -74,6 +74,22 @@ fn insert_queued_reset(a: &mut Association, rsn: u32, stream_id: StreamId) {
     a.control_queue.push_back(packet);
 }
 
+fn reconfig_response_result(packets: &[Packet], rsn: u32) -> Option<ReconfigResult> {
+    packets.iter().find_map(|packet| {
+        packet.chunks.iter().find_map(|chunk| {
+            let reconfig = chunk.as_any().downcast_ref::<ChunkReconfig>()?;
+            reconfig
+                .param_a
+                .iter()
+                .chain(reconfig.param_b.iter())
+                .find_map(|param| {
+                    let response = param.as_any().downcast_ref::<ParamReconfigResponse>()?;
+                    (response.reconfig_response_sequence_number == rsn).then_some(response.result)
+                })
+        })
+    })
+}
+
 #[test]
 fn test_reconfig_in_progress_timeout_does_not_consume_retry_budget() -> Result<()> {
     let now = Instant::now();
@@ -1143,8 +1159,9 @@ fn test_data_above_deferred_reset_boundary_waits_for_new_generation() -> Result<
         "post-reset DATA must not be readable before the reset boundary arrives"
     );
 
-    // Once TSN 1 arrives, the old generation is reset and held TSN 2 is
-    // delivered into a newly created generation whose SSN starts at zero.
+    // Once TSN 1 arrives, its payload remains readable as the last message of
+    // the old generation. Held TSN 2 is released only after that generation is
+    // drained, into a newly created generation whose SSN starts at zero.
     a.handle_data(&ChunkPayloadData {
         tsn: 1,
         stream_identifier: stream_id,
@@ -1158,7 +1175,155 @@ fn test_data_above_deferred_reset_boundary_waits_for_new_generation() -> Result<
     let message = a.stream(stream_id)?.read()?.unwrap();
     let mut payload = [0; 3];
     assert_eq!(message.read(&mut payload)?, payload.len());
+    assert_eq!(&payload, b"old");
+
+    let message = a.stream(stream_id)?.read()?.unwrap();
+    let mut payload = [0; 3];
+    assert_eq!(message.read(&mut payload)?, payload.len());
     assert_eq!(&payload, b"new");
+    Ok(())
+}
+
+#[test]
+fn test_reset_boundary_data_remains_readable_before_finished() -> Result<()> {
+    let stream_id = 1;
+    let mut a = Association {
+        state: AssociationState::Established,
+        peer_last_tsn: 0,
+        my_next_tsn: 1,
+        max_receive_buffer_size: 1024,
+        max_receive_message_size: 1024,
+        max_payload_size: 1200,
+        ..Default::default()
+    };
+    assert!(
+        a.create_stream(stream_id, false, PayloadProtocolIdentifier::Binary)
+            .is_some()
+    );
+
+    let request: Box<dyn Param + Send + Sync> = Box::new(ParamOutgoingResetRequest {
+        reconfig_request_sequence_number: 7,
+        reconfig_response_sequence_number: u32::MAX,
+        sender_last_tsn: 1,
+        stream_identifiers: vec![stream_id],
+    });
+    a.handle_reconfig_param(&request, &mut vec![])?;
+
+    a.handle_data(&ChunkPayloadData {
+        tsn: 1,
+        stream_identifier: stream_id,
+        stream_sequence_number: 0,
+        beginning_fragment: true,
+        ending_fragment: true,
+        user_data: Bytes::from_static(b"last"),
+        ..Default::default()
+    })?;
+
+    loop {
+        match a.poll() {
+            Some(Event::Stream(StreamEvent::Readable { id })) if id == stream_id => break,
+            Some(Event::Stream(StreamEvent::Finished { id })) if id == stream_id => {
+                panic!("Finished must not overtake readable boundary DATA")
+            }
+            Some(_) => {}
+            None => panic!("missing Readable event for boundary DATA"),
+        }
+    }
+
+    assert!(
+        a.poll().is_none(),
+        "Finished must remain hidden until the readable boundary DATA is drained"
+    );
+
+    let message = a.stream(stream_id)?.read()?.unwrap();
+    let mut payload = [0; 4];
+    assert_eq!(message.read(&mut payload)?, payload.len());
+    assert_eq!(&payload, b"last");
+    assert!(matches!(
+        core::iter::from_fn(|| a.poll()).find(|event| matches!(
+            event,
+            Event::Stream(StreamEvent::Finished { id }) if *id == stream_id
+        )),
+        Some(Event::Stream(StreamEvent::Finished { id })) if id == stream_id
+    ));
+    Ok(())
+}
+
+#[test]
+fn test_future_peer_reconfig_sequence_is_rejected() -> Result<()> {
+    let stream_id = 1;
+    let mut a = Association {
+        peer_last_tsn: 0,
+        peer_last_reconfig_rsn: 40,
+        peer_reconfig_rsn_initialized: true,
+        my_next_tsn: 1,
+        ..Default::default()
+    };
+    assert!(
+        a.create_stream(stream_id, false, PayloadProtocolIdentifier::Binary)
+            .is_some()
+    );
+
+    let future: Box<dyn Param + Send + Sync> = Box::new(ParamOutgoingResetRequest {
+        reconfig_request_sequence_number: 42,
+        reconfig_response_sequence_number: u32::MAX,
+        sender_last_tsn: a.peer_last_tsn,
+        stream_identifiers: vec![stream_id],
+    });
+    let mut reply = vec![];
+    a.handle_reconfig_param(&future, &mut reply)?;
+
+    assert_eq!(
+        reconfig_response_result(&reply, 42),
+        Some(ReconfigResult::ErrorBadSequenceNumber)
+    );
+    assert_eq!(a.peer_last_reconfig_rsn, 40);
+    assert!(a.max_completed_reconfig_rsn.is_none());
+    assert!(a.streams.contains_key(&stream_id));
+
+    let expected: Box<dyn Param + Send + Sync> = Box::new(ParamOutgoingResetRequest {
+        reconfig_request_sequence_number: 41,
+        reconfig_response_sequence_number: u32::MAX,
+        sender_last_tsn: a.peer_last_tsn,
+        stream_identifiers: vec![stream_id],
+    });
+    a.handle_reconfig_param(&expected, &mut vec![])?;
+    assert!(!a.streams.contains_key(&stream_id));
+    assert_eq!(a.max_completed_reconfig_rsn, Some(41));
+    Ok(())
+}
+
+#[test]
+fn test_peer_reconfig_sequence_accepts_wrap_to_zero() -> Result<()> {
+    let stream_id = 1;
+    let mut a = Association {
+        peer_last_tsn: 0,
+        peer_last_reconfig_rsn: u32::MAX,
+        peer_reconfig_rsn_initialized: true,
+        my_next_tsn: 1,
+        ..Default::default()
+    };
+    assert!(
+        a.create_stream(stream_id, false, PayloadProtocolIdentifier::Binary)
+            .is_some()
+    );
+
+    let request: Box<dyn Param + Send + Sync> = Box::new(ParamOutgoingResetRequest {
+        reconfig_request_sequence_number: 0,
+        reconfig_response_sequence_number: u32::MAX,
+        sender_last_tsn: a.peer_last_tsn,
+        stream_identifiers: vec![stream_id],
+    });
+    let mut reply = vec![];
+    a.handle_reconfig_param(&request, &mut reply)?;
+
+    assert_ne!(
+        reconfig_response_result(&reply, 0),
+        Some(ReconfigResult::ErrorBadSequenceNumber)
+    );
+    assert_eq!(a.peer_last_reconfig_rsn, 0);
+    assert_eq!(a.max_completed_reconfig_rsn, Some(0));
+    assert!(!a.streams.contains_key(&stream_id));
     Ok(())
 }
 

--- a/src/association/association_test.rs
+++ b/src/association/association_test.rs
@@ -917,6 +917,42 @@ fn test_reset_request_sequence_number_wraps() -> Result<()> {
 }
 
 #[test]
+fn test_local_reset_acknowledges_latest_peer_request_sequence() -> Result<()> {
+    let peer_rsn = 41;
+    let mut a = Association {
+        state: AssociationState::Established,
+        my_next_tsn: 1,
+        ..Default::default()
+    };
+
+    let peer_request: Box<dyn Param + Send + Sync> = Box::new(ParamOutgoingResetRequest {
+        reconfig_request_sequence_number: peer_rsn,
+        reconfig_response_sequence_number: u32::MAX,
+        sender_last_tsn: a.peer_last_tsn,
+        stream_identifiers: vec![],
+    });
+    a.handle_reconfig_param(&peer_request, &mut vec![])?;
+    assert_eq!(a.max_completed_reconfig_rsn, Some(peer_rsn));
+
+    a.send_reset_request(1)?;
+    let _ = a.gather_outbound(Instant::now());
+
+    let reset = a
+        .reconfigs
+        .get(&a.active_reconfig.unwrap())
+        .unwrap()
+        .param_a
+        .as_ref()
+        .and_then(|param| param.as_any().downcast_ref::<ParamOutgoingResetRequest>())
+        .unwrap();
+    assert_eq!(
+        reset.reconfig_response_sequence_number, peer_rsn,
+        "RFC 6525 section 5.1.2 A4 requires the latest peer RSN in the response field"
+    );
+    Ok(())
+}
+
+#[test]
 fn test_reciprocal_reset_covers_preexisting_pending_data() -> Result<()> {
     let stream_id = 1;
     let mut a = Association {

--- a/src/association/association_test.rs
+++ b/src/association/association_test.rs
@@ -1985,6 +1985,49 @@ fn test_cross_generation_forward_tsn_does_not_skip_uncovered_successor_ssn() -> 
 }
 
 #[test]
+fn test_successor_forward_tsn_releases_covered_message_before_lost_tail() -> Result<()> {
+    let mut a = association_with_queued_second_reset()?;
+    a.handle_forward_tsn(&ChunkForwardTsn {
+        new_cumulative_tsn: 2,
+        streams: vec![ChunkForwardTsnStream {
+            identifier: 1,
+            sequence: 0,
+        }],
+    })?;
+    a.handle_data(&ChunkPayloadData {
+        tsn: 4,
+        stream_identifier: 1,
+        stream_sequence_number: 1,
+        beginning_fragment: true,
+        ending_fragment: true,
+        user_data: Bytes::from_static(b"one"),
+        ..Default::default()
+    })?;
+
+    // Successor SSN 0/TSN 3 and SSN 2/TSN 5 were both abandoned. The
+    // complete covered SSN 1 can be released before SSN 2 is observed.
+    a.handle_forward_tsn(&ChunkForwardTsn {
+        new_cumulative_tsn: 5,
+        streams: vec![ChunkForwardTsnStream {
+            identifier: 1,
+            sequence: 2,
+        }],
+    })?;
+
+    let old = a.stream(1)?.read()?.unwrap();
+    let mut payload = [0; 3];
+    assert_eq!(old.read(&mut payload)?, payload.len());
+    let one = a
+        .stream(1)?
+        .read()?
+        .expect("covered successor data must not wait for the lost final SSN");
+    let mut payload = [0; 3];
+    assert_eq!(one.read(&mut payload)?, payload.len());
+    assert_eq!(&payload, b"one");
+    Ok(())
+}
+
+#[test]
 fn test_i_forward_tsn_skip_is_scoped_to_queued_reset_generation() -> Result<()> {
     let mut a = association_with_queued_second_reset()?;
     a.handle_i_forward_tsn(&ChunkIForwardTsn {

--- a/src/association/association_test.rs
+++ b/src/association/association_test.rs
@@ -1558,6 +1558,177 @@ fn test_i_forward_tsn_skip_is_scoped_to_queued_reset_generation() -> Result<()> 
     assert_generation_c_ssn_zero_is_readable(a)
 }
 
+fn assert_later_reset_claims_tail_forward_tsn(mut a: Association) -> Result<()> {
+    let second_reset: Box<dyn Param + Send + Sync> = Box::new(ParamOutgoingResetRequest {
+        reconfig_request_sequence_number: 8,
+        reconfig_response_sequence_number: u32::MAX,
+        sender_last_tsn: 2,
+        stream_identifiers: vec![1],
+    });
+    a.handle_reconfig_param(&second_reset, &mut vec![])?;
+
+    let old = a.stream(1)?.read()?.unwrap();
+    let mut payload = [0; 3];
+    assert_eq!(old.read(&mut payload)?, payload.len());
+    assert_eq!(&payload, b"old");
+
+    a.handle_data(&ChunkPayloadData {
+        tsn: 3,
+        stream_identifier: 1,
+        stream_sequence_number: 0,
+        beginning_fragment: true,
+        ending_fragment: true,
+        user_data: Bytes::from_static(b"gen-c"),
+        ..Default::default()
+    })?;
+    let generation_c = a.stream(1)?.read()?.unwrap();
+    let mut payload = [0; 5];
+    assert_eq!(generation_c.read(&mut payload)?, payload.len());
+    assert_eq!(&payload, b"gen-c");
+    Ok(())
+}
+
+#[test]
+fn test_later_reset_claims_tail_forward_tsn_generation() -> Result<()> {
+    let mut a = association_with_retiring_boundary_data()?;
+    a.handle_forward_tsn(&ChunkForwardTsn {
+        new_cumulative_tsn: 2,
+        streams: vec![ChunkForwardTsnStream {
+            identifier: 1,
+            sequence: 0,
+        }],
+    })?;
+    assert_later_reset_claims_tail_forward_tsn(a)
+}
+
+#[test]
+fn test_later_reset_claims_tail_i_forward_tsn_generation() -> Result<()> {
+    let mut a = association_with_retiring_boundary_data()?;
+    a.handle_i_forward_tsn(&ChunkIForwardTsn {
+        new_cumulative_tsn: 2,
+        streams: vec![ChunkIForwardTsnStream {
+            identifier: 1,
+            unordered: false,
+            mid: 0,
+        }],
+    })?;
+    assert_later_reset_claims_tail_forward_tsn(a)
+}
+
+fn association_with_complete_deferred_successor() -> Result<Association> {
+    let mut a = association_with_retiring_boundary_data()?;
+    a.handle_data(&ChunkPayloadData {
+        tsn: 2,
+        stream_identifier: 1,
+        stream_sequence_number: 0,
+        beginning_fragment: true,
+        ending_fragment: true,
+        user_data: Bytes::from_static(b"received"),
+        ..Default::default()
+    })?;
+    Ok(a)
+}
+
+fn assert_received_message_survives_forward_tsn(mut a: Association) -> Result<()> {
+    let old = a.stream(1)?.read()?.unwrap();
+    let mut payload = [0; 3];
+    assert_eq!(old.read(&mut payload)?, payload.len());
+    assert_eq!(&payload, b"old");
+
+    let received = a.stream(1)?.read()?.unwrap();
+    let mut payload = [0; 8];
+    assert_eq!(received.read(&mut payload)?, payload.len());
+    assert_eq!(&payload, b"received");
+    Ok(())
+}
+
+#[test]
+fn test_forward_tsn_preserves_complete_deferred_message() -> Result<()> {
+    let mut a = association_with_complete_deferred_successor()?;
+    a.handle_forward_tsn(&ChunkForwardTsn {
+        // SSN 0 was received completely; only the following SSN 1 was
+        // abandoned. RFC 3758 requires the stranded complete message to be
+        // made available when the skip advances the ordered stream.
+        new_cumulative_tsn: 3,
+        streams: vec![ChunkForwardTsnStream {
+            identifier: 1,
+            sequence: 1,
+        }],
+    })?;
+    assert_received_message_survives_forward_tsn(a)
+}
+
+#[test]
+fn test_i_forward_tsn_preserves_complete_deferred_message() -> Result<()> {
+    let mut a = association_with_complete_deferred_successor()?;
+    a.handle_i_forward_tsn(&ChunkIForwardTsn {
+        new_cumulative_tsn: 3,
+        streams: vec![ChunkIForwardTsnStream {
+            identifier: 1,
+            unordered: false,
+            mid: 1,
+        }],
+    })?;
+    assert_received_message_survives_forward_tsn(a)
+}
+
+fn association_with_deferred_unordered_fragment() -> Result<Association> {
+    let mut a = association_with_retiring_boundary_data()?;
+    a.streams.get_mut(&1).unwrap().unordered = true;
+    a.handle_data(&ChunkPayloadData {
+        tsn: 2,
+        stream_identifier: 1,
+        unordered: true,
+        beginning_fragment: true,
+        ending_fragment: false,
+        user_data: Bytes::from_static(b"orphan"),
+        ..Default::default()
+    })?;
+    Ok(a)
+}
+
+fn assert_abandoned_unordered_fragment_is_discarded(mut a: Association) -> Result<()> {
+    let old = a.stream(1)?.read()?.unwrap();
+    let mut payload = [0; 3];
+    assert_eq!(old.read(&mut payload)?, payload.len());
+    assert_eq!(&payload, b"old");
+
+    assert_eq!(
+        a.streams
+            .get(&1)
+            .unwrap()
+            .get_num_bytes_in_reassembly_queue(),
+        0,
+        "an abandoned partial unordered message must not survive replay"
+    );
+    assert_eq!(a.get_my_receiver_window_credit(), a.max_receive_buffer_size);
+    Ok(())
+}
+
+#[test]
+fn test_forward_tsn_discards_deferred_unordered_fragment() -> Result<()> {
+    let mut a = association_with_deferred_unordered_fragment()?;
+    a.handle_forward_tsn(&ChunkForwardTsn {
+        new_cumulative_tsn: 3,
+        streams: vec![],
+    })?;
+    assert_abandoned_unordered_fragment_is_discarded(a)
+}
+
+#[test]
+fn test_i_forward_tsn_discards_deferred_unordered_fragment() -> Result<()> {
+    let mut a = association_with_deferred_unordered_fragment()?;
+    a.handle_i_forward_tsn(&ChunkIForwardTsn {
+        new_cumulative_tsn: 3,
+        streams: vec![ChunkIForwardTsnStream {
+            identifier: 1,
+            unordered: true,
+            mid: 0,
+        }],
+    })?;
+    assert_abandoned_unordered_fragment_is_discarded(a)
+}
+
 #[test]
 fn test_unread_retiring_stream_does_not_block_unrelated_events() -> Result<()> {
     let mut a = association_with_retiring_boundary_data()?;
@@ -1623,6 +1794,136 @@ fn test_stop_does_not_reopen_read_half_on_deferred_successor() -> Result<()> {
     let mut stream = a.stream(1)?;
     stream.stop()?;
     assert_eq!(stream.read().unwrap_err(), Error::ErrStreamClosed);
+    Ok(())
+}
+
+#[test]
+fn test_stop_discards_deferred_successor_bytes_and_notifications() -> Result<()> {
+    let mut a = association_with_retiring_boundary_data()?;
+    while a.poll().is_some() {}
+    a.handle_data(&ChunkPayloadData {
+        tsn: 2,
+        stream_identifier: 1,
+        stream_sequence_number: 0,
+        beginning_fragment: true,
+        ending_fragment: true,
+        user_data: Bytes::from_static(b"successor"),
+        ..Default::default()
+    })?;
+
+    a.stream(1)?.stop()?;
+
+    assert_eq!(
+        a.streams
+            .get(&1)
+            .unwrap()
+            .get_num_bytes_in_reassembly_queue(),
+        0,
+        "stop must not strand bytes in a write-only successor"
+    );
+    assert_eq!(a.get_my_receiver_window_credit(), a.max_receive_buffer_size);
+    assert!(
+        !core::iter::from_fn(|| a.poll()).any(|event| matches!(
+            event,
+            Event::Stream(StreamEvent::Opened { id } | StreamEvent::Readable { id }) if id == 1
+        )),
+        "stop must not advertise an unreadable successor"
+    );
+    Ok(())
+}
+
+#[test]
+fn test_finish_remains_closed_across_deferred_successor() -> Result<()> {
+    let mut a = association_with_retiring_boundary_data()?;
+    a.handle_data(&ChunkPayloadData {
+        tsn: 2,
+        stream_identifier: 1,
+        stream_sequence_number: 0,
+        beginning_fragment: true,
+        ending_fragment: true,
+        user_data: Bytes::from_static(b"successor"),
+        ..Default::default()
+    })?;
+    a.stream(1)?.finish()?;
+
+    let old = a.stream(1)?.read()?.unwrap();
+    let mut payload = [0; 3];
+    assert_eq!(old.read(&mut payload)?, payload.len());
+    assert_eq!(&payload, b"old");
+    assert_eq!(a.streams.get(&1).unwrap().state, RecvSendState::Readable);
+
+    let successor = a.stream(1)?.read()?.unwrap();
+    let mut payload = [0; 9];
+    assert_eq!(successor.read(&mut payload)?, payload.len());
+    assert_eq!(&payload, b"successor");
+    Ok(())
+}
+
+#[test]
+fn test_close_remains_closed_across_deferred_successor() -> Result<()> {
+    let mut a = association_with_retiring_boundary_data()?;
+    a.handle_data(&ChunkPayloadData {
+        tsn: 2,
+        stream_identifier: 1,
+        stream_sequence_number: 0,
+        beginning_fragment: true,
+        ending_fragment: true,
+        user_data: Bytes::from_static(b"successor"),
+        ..Default::default()
+    })?;
+
+    a.stream(1)?.close()?;
+
+    let successor = a.streams.get(&1).unwrap();
+    assert_eq!(successor.state, RecvSendState::Closed);
+    assert_eq!(successor.get_num_bytes_in_reassembly_queue(), 0);
+    assert_eq!(a.get_my_receiver_window_credit(), a.max_receive_buffer_size);
+    Ok(())
+}
+
+#[test]
+fn test_duplicate_stream_ids_retire_only_one_generation() -> Result<()> {
+    let stream_id = 1;
+    let mut a = Association {
+        state: AssociationState::Established,
+        peer_last_tsn: 0,
+        my_next_tsn: 1,
+        max_receive_buffer_size: 1024,
+        max_receive_message_size: 1024,
+        max_payload_size: 1200,
+        ..Default::default()
+    };
+    assert!(
+        a.create_stream(stream_id, false, PayloadProtocolIdentifier::Binary)
+            .is_some()
+    );
+    a.handle_data(&ChunkPayloadData {
+        tsn: 1,
+        stream_identifier: stream_id,
+        stream_sequence_number: 0,
+        beginning_fragment: true,
+        ending_fragment: true,
+        user_data: Bytes::from_static(b"old"),
+        ..Default::default()
+    })?;
+
+    let reset: Box<dyn Param + Send + Sync> = Box::new(ParamOutgoingResetRequest {
+        reconfig_request_sequence_number: 7,
+        reconfig_response_sequence_number: u32::MAX,
+        sender_last_tsn: 1,
+        stream_identifiers: vec![stream_id, stream_id],
+    });
+    a.handle_reconfig_param(&reset, &mut vec![])?;
+
+    assert_eq!(a.retiring_streams.get(&stream_id).unwrap().len(), 1);
+    assert_eq!(a.pending_reset_completions.0.get(&stream_id), Some(&1));
+    assert_eq!(
+        a.reconfigs
+            .values()
+            .flat_map(Association::reconfig_stream_ids)
+            .collect::<Vec<_>>(),
+        vec![stream_id]
+    );
     Ok(())
 }
 

--- a/src/association/association_test.rs
+++ b/src/association/association_test.rs
@@ -1721,6 +1721,118 @@ fn test_repeated_old_forward_tsn_preserves_partial_successor_above_cumulative() 
 }
 
 #[test]
+fn test_deferred_forward_tsn_discards_partial_missing_pre_cumulative_tsn() -> Result<()> {
+    let mut a = association_with_retiring_boundary_data()?;
+    let reset: Box<dyn Param + Send + Sync> = Box::new(ParamOutgoingResetRequest {
+        reconfig_request_sequence_number: 8,
+        reconfig_response_sequence_number: u32::MAX,
+        sender_last_tsn: 4,
+        stream_identifiers: vec![1],
+    });
+    a.handle_reconfig_param(&reset, &mut vec![])?;
+
+    // B/SSN 0 is missing its beginning at TSN 2, while B/SSN 1 is complete.
+    for chunk in [
+        ChunkPayloadData {
+            tsn: 3,
+            stream_identifier: 1,
+            stream_sequence_number: 0,
+            beginning_fragment: false,
+            ending_fragment: true,
+            user_data: Bytes::from_static(b"orphan"),
+            ..Default::default()
+        },
+        ChunkPayloadData {
+            tsn: 4,
+            stream_identifier: 1,
+            stream_sequence_number: 1,
+            beginning_fragment: true,
+            ending_fragment: true,
+            user_data: Bytes::from_static(b"next"),
+            ..Default::default()
+        },
+    ] {
+        a.handle_data(&chunk)?;
+    }
+    a.handle_forward_tsn(&ChunkForwardTsn {
+        new_cumulative_tsn: 2,
+        streams: vec![ChunkForwardTsnStream {
+            identifier: 1,
+            sequence: 0,
+        }],
+    })?;
+
+    assert_eq!(
+        a.get_my_receiver_window_credit(),
+        a.max_receive_buffer_size - 3 - 4,
+        "the partial message missing TSN 2 must release its six bytes immediately"
+    );
+    let old = a.stream(1)?.read()?.unwrap();
+    let mut payload = [0; 3];
+    assert_eq!(old.read(&mut payload)?, payload.len());
+
+    let next = a
+        .stream(1)?
+        .read()?
+        .expect("discarding abandoned SSN 0 must unblock complete SSN 1");
+    let mut payload = [0; 4];
+    assert_eq!(next.read(&mut payload)?, payload.len());
+    assert_eq!(&payload, b"next");
+    Ok(())
+}
+
+#[test]
+fn test_reordered_successor_waits_before_consuming_old_forward_tsn() -> Result<()> {
+    let mut a = association_with_queued_second_reset()?;
+    for new_cumulative_tsn in [2, 3] {
+        a.handle_forward_tsn(&ChunkForwardTsn {
+            new_cumulative_tsn,
+            streams: vec![ChunkForwardTsnStream {
+                identifier: 1,
+                sequence: 0,
+            }],
+        })?;
+    }
+    a.handle_data(&ChunkPayloadData {
+        tsn: 5,
+        stream_identifier: 1,
+        stream_sequence_number: 1,
+        beginning_fragment: true,
+        ending_fragment: true,
+        user_data: Bytes::from_static(b"one"),
+        ..Default::default()
+    })?;
+
+    let old = a.stream(1)?.read()?.unwrap();
+    let mut payload = [0; 3];
+    assert_eq!(old.read(&mut payload)?, payload.len());
+    assert!(
+        a.stream(1)?.read()?.is_none(),
+        "SSN 1 must wait while SSN 0's post-FWD TSN is still missing"
+    );
+
+    a.handle_data(&ChunkPayloadData {
+        tsn: 4,
+        stream_identifier: 1,
+        stream_sequence_number: 0,
+        beginning_fragment: true,
+        ending_fragment: true,
+        user_data: Bytes::from_static(b"zero"),
+        ..Default::default()
+    })?;
+    for expected in [b"zero".as_slice(), b"one".as_slice()] {
+        let message = a
+            .stream(1)?
+            .read()?
+            .expect("successor messages should become readable in SSN order");
+        let mut payload = [0; 4];
+        assert_eq!(message.read(&mut payload)?, expected.len());
+        assert_eq!(&payload[..expected.len()], expected);
+    }
+    Ok(())
+}
+
+#[test]
 fn test_i_forward_tsn_skip_is_scoped_to_queued_reset_generation() -> Result<()> {
     let mut a = association_with_queued_second_reset()?;
     a.handle_i_forward_tsn(&ChunkIForwardTsn {

--- a/src/association/association_test.rs
+++ b/src/association/association_test.rs
@@ -62,6 +62,18 @@ fn outgoing_reset(rsn: u32, stream_id: StreamId) -> ChunkReconfig {
     }
 }
 
+fn insert_active_reset(a: &mut Association, rsn: u32, stream_id: StreamId) {
+    a.reconfigs.insert(rsn, outgoing_reset(rsn, stream_id));
+    a.active_reconfig = Some(rsn);
+}
+
+fn insert_queued_reset(a: &mut Association, rsn: u32, stream_id: StreamId) {
+    let reset = outgoing_reset(rsn, stream_id);
+    a.reconfigs.insert(rsn, reset.clone());
+    let packet = a.create_packet(vec![Box::new(reset)]);
+    a.control_queue.push_back(packet);
+}
+
 #[test]
 fn test_reconfig_in_progress_timeout_does_not_consume_retry_budget() -> Result<()> {
     let now = Instant::now();
@@ -72,7 +84,7 @@ fn test_reconfig_in_progress_timeout_does_not_consume_retry_budget() -> Result<(
             .with_rto_initial_ms(1),
     );
 
-    a.reconfigs.insert(rsn, outgoing_reset(rsn, 1));
+    insert_active_reset(&mut a, rsn, 1);
     a.timers.start(Timer::Reconfig, now, a.rto_mgr.get_rto());
 
     let response: Box<dyn Param + Send + Sync> = Box::new(ParamReconfigResponse {
@@ -111,7 +123,7 @@ fn test_reset_complete_only_for_successful_reconfig_response() -> Result<()> {
     ] {
         let mut a = Association::default();
         a.pending_reset_completions.insert(stream_id);
-        a.reconfigs.insert(rsn, outgoing_reset(rsn, stream_id));
+        insert_active_reset(&mut a, rsn, stream_id);
 
         let response: Box<dyn Param + Send + Sync> = Box::new(ParamReconfigResponse {
             reconfig_response_sequence_number: rsn,
@@ -134,28 +146,31 @@ fn test_reset_complete_only_for_successful_reconfig_response() -> Result<()> {
 }
 
 #[test]
-fn test_reconfig_retransmission_failure_does_not_complete_reset() {
+fn test_reconfig_retransmission_failure_is_terminal() {
     let rsn = 7;
     let stream_id = 1;
     let mut a = Association::default();
     a.pending_reset_completions.insert(stream_id);
-    a.reconfigs.insert(rsn, outgoing_reset(rsn, stream_id));
+    insert_active_reset(&mut a, rsn, stream_id);
 
     a.on_retransmission_failure(Timer::Reconfig);
 
-    assert!(!matches!(
+    assert!(matches!(
         a.poll(),
-        Some(Event::Stream(StreamEvent::ResetComplete { id })) if id == stream_id
+        Some(Event::Stream(StreamEvent::ResetFailed {
+            id,
+            reason: StreamResetError::Failed,
+        })) if id == stream_id
     ));
 }
 
 #[test]
-fn test_denied_reset_remains_quarantined_without_terminal_event() -> Result<()> {
+fn test_denied_reset_emits_terminal_event_and_remains_quarantined() -> Result<()> {
     let rsn = 7;
     let stream_id = 1;
     let mut a = Association::default();
     a.pending_reset_completions.insert(stream_id);
-    a.reconfigs.insert(rsn, outgoing_reset(rsn, stream_id));
+    insert_active_reset(&mut a, rsn, stream_id);
 
     let response: Box<dyn Param + Send + Sync> = Box::new(ParamReconfigResponse {
         reconfig_response_sequence_number: rsn,
@@ -163,13 +178,14 @@ fn test_denied_reset_remains_quarantined_without_terminal_event() -> Result<()> 
     });
     a.handle_reconfig_param(&response, &mut vec![])?;
 
-    // Until the public API has a ResetFailed/ResetDenied event, forgetting
-    // this generation would leave the caller unable to distinguish an unsafe
-    // ID from one whose reset completed.
-    assert!(
-        a.pending_reset_completions.contains(&stream_id),
-        "a failed reset needs either a terminal event or continued quarantine"
-    );
+    assert!(matches!(
+        a.poll(),
+        Some(Event::Stream(StreamEvent::ResetFailed {
+            id,
+            reason: StreamResetError::Denied,
+        })) if id == stream_id
+    ));
+    assert!(!a.pending_reset_completions.contains(&stream_id));
     assert!(
         matches!(
             a.open_stream(stream_id, PayloadProtocolIdentifier::Binary),
@@ -232,6 +248,7 @@ fn test_reset_complete_preserves_generations_through_responses() -> Result<()> {
         .insert(second_rsn, outgoing_reset(second_rsn, stream_id));
 
     for rsn in [first_rsn, second_rsn] {
+        a.active_reconfig = Some(rsn);
         let response: Box<dyn Param + Send + Sync> = Box::new(ParamReconfigResponse {
             reconfig_response_sequence_number: rsn,
             result: ReconfigResult::SuccessPerformed,
@@ -269,6 +286,7 @@ fn test_overlapping_generations_success_then_denied_reports_success() -> Result<
         (7, ReconfigResult::SuccessPerformed),
         (8, ReconfigResult::Denied),
     ] {
+        a.active_reconfig = Some(rsn);
         let response: Box<dyn Param + Send + Sync> = Box::new(ParamReconfigResponse {
             reconfig_response_sequence_number: rsn,
             result,
@@ -306,6 +324,7 @@ fn test_overlapping_generations_denied_then_success_reports_only_success() -> Re
         (7, ReconfigResult::Denied),
         (8, ReconfigResult::SuccessPerformed),
     ] {
+        a.active_reconfig = Some(rsn);
         let response: Box<dyn Param + Send + Sync> = Box::new(ParamReconfigResponse {
             reconfig_response_sequence_number: rsn,
             result,
@@ -335,8 +354,7 @@ fn test_outgoing_reset_implicitly_acknowledges_pending_request() -> Result<()> {
     let stream_id = 1;
     let mut a = Association::default();
 
-    a.reconfigs
-        .insert(local_rsn, outgoing_reset(local_rsn, stream_id));
+    insert_active_reset(&mut a, local_rsn, stream_id);
     a.timers
         .start(Timer::Reconfig, Instant::now(), a.rto_mgr.get_rto());
 
@@ -416,7 +434,7 @@ fn test_outgoing_reset_does_not_ack_unsent_reciprocal() -> Result<()> {
 }
 
 #[test]
-fn test_reset_complete_only_fires_when_stream_id_is_reusable() -> Result<()> {
+fn test_reset_complete_does_not_override_newer_failure() -> Result<()> {
     let stream_id = 1;
     let mut a = Association::default();
 
@@ -429,6 +447,7 @@ fn test_reset_complete_only_fires_when_stream_id_is_reusable() -> Result<()> {
         (7, ReconfigResult::SuccessPerformed),
         (8, ReconfigResult::Denied),
     ] {
+        a.active_reconfig = Some(rsn);
         let response: Box<dyn Param + Send + Sync> = Box::new(ParamReconfigResponse {
             reconfig_response_sequence_number: rsn,
             result,
@@ -440,11 +459,17 @@ fn test_reset_complete_only_fires_when_stream_id_is_reusable() -> Result<()> {
         a.poll(),
         Some(Event::Stream(StreamEvent::ResetComplete { id })) if id == stream_id
     ));
-    assert!(
-        a.open_stream(stream_id, PayloadProtocolIdentifier::Binary)
-            .is_ok(),
-        "ResetComplete promises that this stream ID has become reusable"
-    );
+    assert!(matches!(
+        a.poll(),
+        Some(Event::Stream(StreamEvent::ResetFailed {
+            id,
+            reason: StreamResetError::Denied,
+        })) if id == stream_id
+    ));
+    assert!(matches!(
+        a.open_stream(stream_id, PayloadProtocolIdentifier::Binary),
+        Err(Error::ErrStreamResetPending)
+    ));
     Ok(())
 }
 
@@ -510,7 +535,7 @@ fn test_outgoing_reset_does_not_ack_unsent_reciprocal_with_unrelated_timer() -> 
             .is_some()
     );
 
-    a.reconfigs.insert(sent_rsn, outgoing_reset(sent_rsn, 2));
+    insert_active_reset(&mut a, sent_rsn, 2);
     a.timers
         .start(Timer::Reconfig, Instant::now(), a.rto_mgr.get_rto());
 
@@ -568,6 +593,7 @@ fn test_failed_generation_stays_quarantined_after_other_success() -> Result<()> 
         (7, ReconfigResult::SuccessPerformed),
         (8, ReconfigResult::Denied),
     ] {
+        a.active_reconfig = Some(rsn);
         let response: Box<dyn Param + Send + Sync> = Box::new(ParamReconfigResponse {
             reconfig_response_sequence_number: rsn,
             result,
@@ -596,7 +622,7 @@ fn test_second_reconfig_request_stays_buffered_while_timer_runs() -> Result<()> 
             .is_some()
     );
 
-    a.reconfigs.insert(sent_rsn, outgoing_reset(sent_rsn, 2));
+    insert_active_reset(&mut a, sent_rsn, 2);
     a.timers
         .start(Timer::Reconfig, Instant::now(), a.rto_mgr.get_rto());
 
@@ -613,14 +639,25 @@ fn test_second_reconfig_request_stays_buffered_while_timer_runs() -> Result<()> 
     a.handle_reconfig_param(&request, &mut reply)?;
 
     let reciprocal_rsn = *a.reconfigs.keys().find(|&&rsn| rsn != sent_rsn).unwrap();
-    assert!(a.unsent_reconfigs.contains(&reciprocal_rsn));
     a.control_queue.extend(reply);
 
     assert!(a.poll_transmit(Instant::now()).is_some());
-    assert!(
-        a.unsent_reconfigs.contains(&reciprocal_rsn),
+    assert_eq!(
+        a.active_reconfig,
+        Some(sent_rsn),
         "a second request must remain buffered while the first request's timer runs"
     );
+    assert!(a.reconfigs.contains_key(&reciprocal_rsn));
+    assert_eq!(a.control_queue.len(), 1);
+
+    let response: Box<dyn Param + Send + Sync> = Box::new(ParamReconfigResponse {
+        reconfig_response_sequence_number: sent_rsn,
+        result: ReconfigResult::SuccessPerformed,
+    });
+    a.handle_reconfig_param(&response, &mut vec![])?;
+    assert!(a.poll_transmit(Instant::now()).is_some());
+    assert_eq!(a.active_reconfig, Some(reciprocal_rsn));
+    assert!(a.control_queue.is_empty());
     Ok(())
 }
 
@@ -633,12 +670,29 @@ fn test_peer_recreated_quarantined_stream_is_not_writable() -> Result<()> {
     // outgoing reset is acknowledged. Reading that generation is safe, but
     // sending with a freshly initialized SSN is not yet safe.
     a.pending_reset_completions.insert(stream_id);
-    a.reconfigs.insert(7, outgoing_reset(7, stream_id));
+    insert_active_reset(&mut a, 7, stream_id);
 
     assert!(a.get_or_create_stream(stream_id).is_some());
     assert!(
         !a.stream(stream_id)?.is_writable(),
         "a pending reciprocal reset must quarantine the outgoing direction"
+    );
+    Ok(())
+}
+
+#[test]
+fn test_pending_reset_blocks_existing_stream_writes() -> Result<()> {
+    let stream_id = 1;
+    let mut a = Association::default();
+    assert!(
+        a.create_stream(stream_id, false, PayloadProtocolIdentifier::Binary)
+            .is_some()
+    );
+    insert_active_reset(&mut a, 7, stream_id);
+
+    assert!(
+        !a.stream(stream_id)?.is_writable(),
+        "new SSNs must not be assigned while an outgoing reset is pending"
     );
     Ok(())
 }
@@ -651,20 +705,23 @@ fn test_only_one_buffered_reconfig_is_sent_when_timer_is_idle() {
     };
 
     for (rsn, stream_id) in [(7, 1), (8, 2)] {
-        let c = outgoing_reset(rsn, stream_id);
-        a.reconfigs.insert(rsn, c.clone());
-        a.unsent_reconfigs.insert(rsn);
-        let packet = a.create_packet(vec![Box::new(c)]);
-        a.control_queue.push_back(packet);
+        insert_queued_reset(&mut a, rsn, stream_id);
     }
     assert!(a.timers.get(Timer::Reconfig).is_none());
 
     assert!(a.poll_transmit(Instant::now()).is_some());
-    assert_eq!(
-        a.unsent_reconfigs.len(),
-        1,
-        "RFC 6525 permits only one reconfiguration request in flight"
-    );
+    assert_eq!(a.active_reconfig, Some(7));
+    assert_eq!(a.control_queue.len(), 1);
+    assert!(a.reconfigs.contains_key(&8));
+
+    let response: Box<dyn Param + Send + Sync> = Box::new(ParamReconfigResponse {
+        reconfig_response_sequence_number: 7,
+        result: ReconfigResult::SuccessPerformed,
+    });
+    a.handle_reconfig_param(&response, &mut vec![]).unwrap();
+    assert!(a.poll_transmit(Instant::now()).is_some());
+    assert_eq!(a.active_reconfig, Some(8));
+    assert!(a.control_queue.is_empty());
 }
 
 #[test]
@@ -674,12 +731,8 @@ fn test_in_progress_keeps_later_request_buffered() -> Result<()> {
         ..Default::default()
     };
 
-    a.reconfigs.insert(7, outgoing_reset(7, 1));
-    let buffered = outgoing_reset(8, 2);
-    a.reconfigs.insert(8, buffered.clone());
-    a.unsent_reconfigs.insert(8);
-    let packet = a.create_packet(vec![Box::new(buffered)]);
-    a.control_queue.push_back(packet);
+    insert_active_reset(&mut a, 7, 1);
+    insert_queued_reset(&mut a, 8, 2);
     a.timers
         .start(Timer::Reconfig, Instant::now(), a.rto_mgr.get_rto());
 
@@ -691,10 +744,8 @@ fn test_in_progress_keeps_later_request_buffered() -> Result<()> {
     assert!(a.reconfigs.contains_key(&7));
 
     let _ = a.poll_transmit(Instant::now());
-    assert!(
-        a.unsent_reconfigs.contains(&8),
-        "InProgress leaves the current request in flight, so the next must stay buffered"
-    );
+    assert_eq!(a.active_reconfig, Some(7));
+    assert_eq!(a.control_queue.len(), 1);
     Ok(())
 }
 
@@ -706,7 +757,7 @@ fn test_local_reset_stays_queued_while_reconfig_timer_runs() -> Result<()> {
         ..Default::default()
     };
 
-    a.reconfigs.insert(7, outgoing_reset(7, 1));
+    insert_active_reset(&mut a, 7, 1);
     a.timers
         .start(Timer::Reconfig, Instant::now(), a.rto_mgr.get_rto());
     a.send_reset_request(2)?;
@@ -717,6 +768,48 @@ fn test_local_reset_stays_queued_while_reconfig_timer_runs() -> Result<()> {
         1,
         "a locally initiated reset must remain queued while another request is in flight"
     );
+    assert_eq!(
+        a.pending_reset_streams.iter().copied().collect::<Vec<_>>(),
+        [2]
+    );
+
+    let response: Box<dyn Param + Send + Sync> = Box::new(ParamReconfigResponse {
+        reconfig_response_sequence_number: 7,
+        result: ReconfigResult::SuccessPerformed,
+    });
+    a.handle_reconfig_param(&response, &mut vec![])?;
+    assert!(a.poll_transmit(Instant::now()).is_some());
+    assert_ne!(a.active_reconfig, Some(7));
+    assert!(a.active_reconfig.is_some());
+    assert!(a.pending_reset_streams.is_empty());
+    Ok(())
+}
+
+#[test]
+fn test_local_reset_does_not_overtake_pending_data() -> Result<()> {
+    let mut a = Association {
+        state: AssociationState::Established,
+        my_next_tsn: 1,
+        ..Default::default()
+    };
+    a.inflight_queue.push_no_check(ChunkPayloadData {
+        tsn: 1,
+        user_data: Bytes::from_static(b"inflight"),
+        ..Default::default()
+    });
+    a.pending_queue.push(ChunkPayloadData {
+        stream_identifier: 1,
+        beginning_fragment: true,
+        ending_fragment: true,
+        user_data: Bytes::from_static(b"pending"),
+        ..Default::default()
+    });
+    a.send_reset_request(1)?;
+
+    let _ = a.poll_transmit(Instant::now());
+    assert!(a.active_reconfig.is_none());
+    assert!(a.reconfigs.is_empty());
+    assert_eq!(a.pending_reset_streams.len(), 1);
     Ok(())
 }
 
@@ -727,13 +820,8 @@ fn test_retransmission_does_not_send_buffered_reconfigs() {
         ..Default::default()
     };
 
-    let active = outgoing_reset(7, 1);
-    let buffered = outgoing_reset(8, 2);
-    a.reconfigs.insert(7, active);
-    a.reconfigs.insert(8, buffered.clone());
-    a.unsent_reconfigs.insert(8);
-    a.control_queue
-        .push_back(a.create_packet(vec![Box::new(buffered)]));
+    insert_active_reset(&mut a, 7, 1);
+    insert_queued_reset(&mut a, 8, 2);
     a.timers
         .start(Timer::Reconfig, Instant::now(), a.rto_mgr.get_rto());
     a.will_retransmit_reconfig = true;
@@ -753,9 +841,8 @@ fn test_older_completion_does_not_make_newer_generation_writable() -> Result<()>
 
     a.pending_reset_completions.insert(stream_id);
     a.pending_reset_completions.insert(stream_id);
-    a.reconfigs.insert(7, outgoing_reset(7, stream_id));
-    a.reconfigs.insert(8, outgoing_reset(8, stream_id));
-    a.unsent_reconfigs.insert(8);
+    insert_active_reset(&mut a, 7, stream_id);
+    insert_queued_reset(&mut a, 8, stream_id);
     a.timers
         .start(Timer::Reconfig, Instant::now(), a.rto_mgr.get_rto());
 
@@ -782,7 +869,7 @@ fn test_stale_completion_does_not_override_newer_denial() -> Result<()> {
     let mut a = Association::default();
 
     a.pending_reset_completions.insert(stream_id);
-    a.reconfigs.insert(7, outgoing_reset(7, stream_id));
+    insert_active_reset(&mut a, 7, stream_id);
 
     let success: Box<dyn Param + Send + Sync> = Box::new(ParamReconfigResponse {
         reconfig_response_sequence_number: 7,
@@ -796,7 +883,7 @@ fn test_stale_completion_does_not_override_newer_denial() -> Result<()> {
     assert!(a.get_or_create_stream(stream_id).is_some());
     a.streams.get_mut(&stream_id).unwrap().sequence_number = 1;
     a.unregister_stream(stream_id, true);
-    a.reconfigs.insert(8, outgoing_reset(8, stream_id));
+    insert_active_reset(&mut a, 8, stream_id);
     a.timers
         .start(Timer::Reconfig, Instant::now(), a.rto_mgr.get_rto());
 

--- a/src/association/association_test.rs
+++ b/src/association/association_test.rs
@@ -868,6 +868,55 @@ fn test_local_reset_does_not_overtake_pending_data() -> Result<()> {
 }
 
 #[test]
+fn test_reset_sender_last_tsn_wraps_at_zero() -> Result<()> {
+    let stream_id = 1;
+    let mut a = Association {
+        state: AssociationState::Established,
+        my_next_tsn: 0,
+        ..Default::default()
+    };
+    a.send_reset_request(stream_id)?;
+
+    let _ = a.gather_outbound(Instant::now());
+
+    let reset = a
+        .reconfigs
+        .get(&a.active_reconfig.unwrap())
+        .unwrap()
+        .param_a
+        .as_ref()
+        .and_then(|param| param.as_any().downcast_ref::<ParamOutgoingResetRequest>())
+        .unwrap();
+    assert_eq!(
+        reset.sender_last_tsn,
+        u32::MAX,
+        "the TSN preceding zero must wrap to u32::MAX"
+    );
+    Ok(())
+}
+
+#[test]
+fn test_reset_request_sequence_number_wraps() -> Result<()> {
+    let stream_id = 1;
+    let mut a = Association {
+        state: AssociationState::Established,
+        my_next_tsn: 1,
+        my_next_rsn: u32::MAX,
+        ..Default::default()
+    };
+    a.send_reset_request(stream_id)?;
+
+    let _ = a.gather_outbound(Instant::now());
+
+    assert_eq!(a.active_reconfig, Some(u32::MAX));
+    assert_eq!(
+        a.my_next_rsn, 0,
+        "the re-configuration request sequence number must wrap"
+    );
+    Ok(())
+}
+
+#[test]
 fn test_reciprocal_reset_covers_preexisting_pending_data() -> Result<()> {
     let stream_id = 1;
     let mut a = Association {

--- a/src/association/association_test.rs
+++ b/src/association/association_test.rs
@@ -1630,6 +1630,97 @@ fn test_successor_i_forward_tsn_can_reuse_reset_mid() -> Result<()> {
 }
 
 #[test]
+fn test_repeated_old_forward_tsn_does_not_skip_later_successor_ssn() -> Result<()> {
+    let mut a = association_with_queued_second_reset()?;
+    for new_cumulative_tsn in [2, 3] {
+        a.handle_forward_tsn(&ChunkForwardTsn {
+            new_cumulative_tsn,
+            streams: vec![ChunkForwardTsnStream {
+                identifier: 1,
+                sequence: 1,
+            }],
+        })?;
+    }
+
+    let old = a.stream(1)?.read()?.unwrap();
+    let mut payload = [0; 3];
+    assert_eq!(old.read(&mut payload)?, payload.len());
+
+    for (tsn, ssn, bytes) in [(4, 0, b"zero".as_slice()), (5, 1, b"one".as_slice())] {
+        a.handle_data(&ChunkPayloadData {
+            tsn,
+            stream_identifier: 1,
+            stream_sequence_number: ssn,
+            beginning_fragment: true,
+            ending_fragment: true,
+            user_data: Bytes::copy_from_slice(bytes),
+            ..Default::default()
+        })?;
+        let message = a
+            .stream(1)?
+            .read()?
+            .expect("an old-generation repeat must not skip a live successor SSN");
+        let mut payload = [0; 4];
+        assert_eq!(message.read(&mut payload)?, bytes.len());
+        assert_eq!(&payload[..bytes.len()], bytes);
+    }
+    Ok(())
+}
+
+#[test]
+fn test_repeated_old_forward_tsn_preserves_partial_successor_above_cumulative() -> Result<()> {
+    let mut a = association_with_queued_second_reset()?;
+    a.handle_forward_tsn(&ChunkForwardTsn {
+        new_cumulative_tsn: 2,
+        streams: vec![ChunkForwardTsnStream {
+            identifier: 1,
+            sequence: 0,
+        }],
+    })?;
+    a.handle_data(&ChunkPayloadData {
+        tsn: 4,
+        stream_identifier: 1,
+        stream_sequence_number: 0,
+        beginning_fragment: true,
+        ending_fragment: false,
+        user_data: Bytes::from_static(b"live-"),
+        ..Default::default()
+    })?;
+
+    // TSN 3 is unrelated to this stream. Repeating generation B's skip must
+    // not discard generation C's fragment at TSN 4.
+    a.handle_forward_tsn(&ChunkForwardTsn {
+        new_cumulative_tsn: 3,
+        streams: vec![ChunkForwardTsnStream {
+            identifier: 1,
+            sequence: 0,
+        }],
+    })?;
+
+    let old = a.stream(1)?.read()?.unwrap();
+    let mut payload = [0; 3];
+    assert_eq!(old.read(&mut payload)?, payload.len());
+    a.handle_data(&ChunkPayloadData {
+        tsn: 5,
+        stream_identifier: 1,
+        stream_sequence_number: 0,
+        beginning_fragment: false,
+        ending_fragment: true,
+        user_data: Bytes::from_static(b"data"),
+        ..Default::default()
+    })?;
+
+    let message = a
+        .stream(1)?
+        .read()?
+        .expect("the successor fragments should still reassemble");
+    let mut payload = [0; 9];
+    assert_eq!(message.read(&mut payload)?, payload.len());
+    assert_eq!(&payload, b"live-data");
+    Ok(())
+}
+
+#[test]
 fn test_i_forward_tsn_skip_is_scoped_to_queued_reset_generation() -> Result<()> {
     let mut a = association_with_queued_second_reset()?;
     a.handle_i_forward_tsn(&ChunkIForwardTsn {
@@ -1897,6 +1988,74 @@ fn test_deferred_unordered_forward_tsn_updates_are_coalesced() -> Result<()> {
 }
 
 #[test]
+fn test_deferred_tail_ordered_forward_tsn_duplicates_are_coalesced() -> Result<()> {
+    let mut a = association_with_retiring_boundary_data()?;
+    for new_cumulative_tsn in 2..=9 {
+        a.handle_forward_tsn(&ChunkForwardTsn {
+            new_cumulative_tsn,
+            streams: vec![ChunkForwardTsnStream {
+                identifier: 1,
+                sequence: 0,
+            }],
+        })?;
+    }
+
+    let ordered: Vec<_> = a.deferred_forward_tsns[&1]
+        .iter()
+        .filter(|update| {
+            update.generation_boundary.is_none()
+                && matches!(update.kind, DeferredForwardTsnKind::Ordered { .. })
+        })
+        .collect();
+    assert_eq!(
+        ordered.len(),
+        1,
+        "lost-SACK repeats for an ambiguous tail SSN should coalesce"
+    );
+    Ok(())
+}
+
+#[test]
+fn test_deferred_bounded_ordered_forward_tsn_updates_are_coalesced() -> Result<()> {
+    let mut a = association_with_retiring_boundary_data()?;
+    let reset: Box<dyn Param + Send + Sync> = Box::new(ParamOutgoingResetRequest {
+        reconfig_request_sequence_number: 8,
+        reconfig_response_sequence_number: u32::MAX,
+        sender_last_tsn: 10,
+        stream_identifiers: vec![1],
+    });
+    a.handle_reconfig_param(&reset, &mut vec![])?;
+
+    for new_cumulative_tsn in 2..=9 {
+        a.handle_forward_tsn(&ChunkForwardTsn {
+            new_cumulative_tsn,
+            streams: vec![ChunkForwardTsnStream {
+                identifier: 1,
+                sequence: (new_cumulative_tsn - 2) as u16,
+            }],
+        })?;
+    }
+
+    let ordered: Vec<_> = a.deferred_forward_tsns[&1]
+        .iter()
+        .filter(|update| {
+            update.generation_boundary == Some(10)
+                && matches!(update.kind, DeferredForwardTsnKind::Ordered { .. })
+        })
+        .collect();
+    assert_eq!(
+        ordered.len(),
+        1,
+        "a newer ordered skip supersedes older skips for the same reset boundary"
+    );
+    assert!(matches!(
+        ordered[0].kind,
+        DeferredForwardTsnKind::Ordered { last_ssn: 7 }
+    ));
+    Ok(())
+}
+
+#[test]
 fn test_unread_retiring_stream_does_not_block_unrelated_events() -> Result<()> {
     let mut a = association_with_retiring_boundary_data()?;
     assert!(
@@ -2000,6 +2159,47 @@ fn test_stop_during_retirement_allows_reuse_after_reset_complete() -> Result<()>
 #[test]
 fn test_close_during_retirement_allows_reuse_after_reset_complete() -> Result<()> {
     assert_shutdown_during_retirement_allows_reuse(true)
+}
+
+fn assert_reset_complete_before_shutdown_allows_reuse(close: bool) -> Result<()> {
+    let mut a = association_with_retiring_boundary_data()?;
+    let rsn = *a.reconfigs.keys().next().unwrap();
+    a.active_reconfig = Some(rsn);
+    let response: Box<dyn Param + Send + Sync> = Box::new(ParamReconfigResponse {
+        reconfig_response_sequence_number: rsn,
+        result: ReconfigResult::SuccessPerformed,
+    });
+    a.handle_reconfig_param(&response, &mut vec![])?;
+
+    if close {
+        a.stream(1)?.close()?;
+    } else {
+        a.stream(1)?.stop()?;
+    }
+
+    assert!(
+        a.pending_reset_streams.is_empty() && a.reconfigs.is_empty(),
+        "shutting down a completed retiring stream must not queue a duplicate reset"
+    );
+    assert!(
+        !a.streams.contains_key(&1),
+        "discarding the retired generation after ResetComplete must remove the stream"
+    );
+    assert!(
+        a.open_stream(1, PayloadProtocolIdentifier::Binary).is_ok(),
+        "the completed stream id should be immediately reusable"
+    );
+    Ok(())
+}
+
+#[test]
+fn test_reset_complete_before_stop_allows_reuse() -> Result<()> {
+    assert_reset_complete_before_shutdown_allows_reuse(false)
+}
+
+#[test]
+fn test_reset_complete_before_close_allows_reuse() -> Result<()> {
+    assert_reset_complete_before_shutdown_allows_reuse(true)
 }
 
 #[test]

--- a/src/association/association_test.rs
+++ b/src/association/association_test.rs
@@ -232,7 +232,7 @@ fn test_reset_complete_preserves_generations_through_responses() -> Result<()> {
         a.handle_reconfig_param(&response, &mut vec![])?;
     }
 
-    let reset_complete = std::iter::from_fn(|| a.poll())
+    let reset_complete = core::iter::from_fn(|| a.poll())
         .filter(|event| {
             matches!(
                 event,

--- a/src/association/association_test.rs
+++ b/src/association/association_test.rs
@@ -698,6 +698,34 @@ fn test_pending_reset_blocks_existing_stream_writes() -> Result<()> {
 }
 
 #[test]
+fn test_reset_completion_does_not_reopen_finished_write_half() -> Result<()> {
+    let stream_id = 1;
+    let rsn = 7;
+    let mut a = Association::default();
+    assert!(
+        a.create_stream(stream_id, false, PayloadProtocolIdentifier::Binary)
+            .is_some()
+    );
+    insert_active_reset(&mut a, rsn, stream_id);
+
+    // Finishing the write half is permanent, including while a reset request
+    // temporarily makes the stream non-writable for protocol reasons.
+    a.stream(stream_id)?.finish()?;
+
+    let response: Box<dyn Param + Send + Sync> = Box::new(ParamReconfigResponse {
+        reconfig_response_sequence_number: rsn,
+        result: ReconfigResult::SuccessPerformed,
+    });
+    a.handle_reconfig_param(&response, &mut vec![])?;
+
+    assert!(
+        !a.stream(stream_id)?.is_writable(),
+        "reset completion must not undo Stream::finish()"
+    );
+    Ok(())
+}
+
+#[test]
 fn test_only_one_buffered_reconfig_is_sent_when_timer_is_idle() {
     let mut a = Association {
         state: AssociationState::Established,

--- a/src/association/association_test.rs
+++ b/src/association/association_test.rs
@@ -806,6 +806,28 @@ fn test_only_one_buffered_reconfig_is_sent_when_timer_is_idle() {
 }
 
 #[test]
+fn test_close_discards_buffered_reconfig_requests() -> Result<()> {
+    let mut a = Association {
+        state: AssociationState::Established,
+        ..Default::default()
+    };
+    insert_active_reset(&mut a, 7, 1);
+    insert_queued_reset(&mut a, 8, 2);
+    a.timers
+        .start(Timer::Reconfig, Instant::now(), a.rto_mgr.get_rto());
+
+    a.close()?;
+
+    assert!(
+        a.poll_transmit(Instant::now()).is_none(),
+        "a closed association must not send a buffered stream-reset request"
+    );
+    assert!(a.active_reconfig.is_none());
+    assert!(a.reconfigs.is_empty());
+    Ok(())
+}
+
+#[test]
 fn test_in_progress_keeps_later_request_buffered() -> Result<()> {
     let mut a = Association {
         state: AssociationState::Established,

--- a/src/association/association_test.rs
+++ b/src/association/association_test.rs
@@ -868,6 +868,61 @@ fn test_local_reset_does_not_overtake_pending_data() -> Result<()> {
 }
 
 #[test]
+fn test_reciprocal_reset_covers_preexisting_pending_data() -> Result<()> {
+    let stream_id = 1;
+    let mut a = Association {
+        state: AssociationState::Established,
+        my_next_tsn: 1,
+        cwnd: 1400,
+        rwnd: 1400,
+        mtu: 1400,
+        ..Default::default()
+    };
+    assert!(
+        a.create_stream(stream_id, false, PayloadProtocolIdentifier::Binary)
+            .is_some()
+    );
+    a.pending_queue.push(ChunkPayloadData {
+        stream_identifier: stream_id,
+        stream_sequence_number: 4,
+        beginning_fragment: true,
+        ending_fragment: true,
+        user_data: Bytes::from_static(b"pending"),
+        ..Default::default()
+    });
+
+    // Receiving the peer's outgoing reset creates a reciprocal outgoing reset.
+    // DATA accepted before that request must be assigned a TSN covered by the
+    // reciprocal request's Sender's Last Assigned TSN boundary.
+    let request: Box<dyn Param + Send + Sync> = Box::new(ParamOutgoingResetRequest {
+        reconfig_request_sequence_number: 7,
+        reconfig_response_sequence_number: u32::MAX,
+        sender_last_tsn: a.peer_last_tsn,
+        stream_identifiers: vec![stream_id],
+    });
+    let mut reply = vec![];
+    a.handle_reconfig_param(&request, &mut reply)?;
+    a.control_queue.extend(reply);
+
+    let _ = a.gather_outbound(Instant::now());
+
+    let data_tsn = a.inflight_queue.get(1).unwrap().tsn;
+    let reciprocal = a
+        .reconfigs
+        .get(&a.active_reconfig.unwrap())
+        .unwrap()
+        .param_a
+        .as_ref()
+        .and_then(|param| param.as_any().downcast_ref::<ParamOutgoingResetRequest>())
+        .unwrap();
+    assert!(
+        sna32gte(reciprocal.sender_last_tsn, data_tsn),
+        "the reciprocal reset boundary must cover DATA queued before the reset"
+    );
+    Ok(())
+}
+
+#[test]
 fn test_retransmission_does_not_send_buffered_reconfigs() {
     let mut a = Association {
         state: AssociationState::Established,

--- a/src/association/association_test.rs
+++ b/src/association/association_test.rs
@@ -1833,6 +1833,57 @@ fn test_reordered_successor_waits_before_consuming_old_forward_tsn() -> Result<(
 }
 
 #[test]
+fn test_reordered_successor_waits_before_consuming_repeated_old_forward_tsn() -> Result<()> {
+    let mut a = association_with_queued_second_reset()?;
+    for new_cumulative_tsn in [2, 3] {
+        a.handle_forward_tsn(&ChunkForwardTsn {
+            new_cumulative_tsn,
+            streams: vec![ChunkForwardTsnStream {
+                identifier: 1,
+                sequence: 1,
+            }],
+        })?;
+    }
+    a.handle_data(&ChunkPayloadData {
+        tsn: 5,
+        stream_identifier: 1,
+        stream_sequence_number: 1,
+        beginning_fragment: true,
+        ending_fragment: true,
+        user_data: Bytes::from_static(b"one"),
+        ..Default::default()
+    })?;
+
+    let old = a.stream(1)?.read()?.unwrap();
+    let mut payload = [0; 3];
+    assert_eq!(old.read(&mut payload)?, payload.len());
+    assert!(
+        a.stream(1)?.read()?.is_none(),
+        "SSN 1 must wait while SSN 0's post-FWD TSN is still missing"
+    );
+
+    a.handle_data(&ChunkPayloadData {
+        tsn: 4,
+        stream_identifier: 1,
+        stream_sequence_number: 0,
+        beginning_fragment: true,
+        ending_fragment: true,
+        user_data: Bytes::from_static(b"zero"),
+        ..Default::default()
+    })?;
+    for expected in [b"zero".as_slice(), b"one".as_slice()] {
+        let message = a
+            .stream(1)?
+            .read()?
+            .expect("successor messages should become readable in SSN order");
+        let mut payload = [0; 4];
+        assert_eq!(message.read(&mut payload)?, expected.len());
+        assert_eq!(&payload[..expected.len()], expected);
+    }
+    Ok(())
+}
+
+#[test]
 fn test_i_forward_tsn_skip_is_scoped_to_queued_reset_generation() -> Result<()> {
     let mut a = association_with_queued_second_reset()?;
     a.handle_i_forward_tsn(&ChunkIForwardTsn {

--- a/src/association/association_test.rs
+++ b/src/association/association_test.rs
@@ -416,6 +416,143 @@ fn test_outgoing_reset_does_not_ack_unsent_reciprocal() -> Result<()> {
 }
 
 #[test]
+fn test_reset_complete_only_fires_when_stream_id_is_reusable() -> Result<()> {
+    let stream_id = 1;
+    let mut a = Association::default();
+
+    a.pending_reset_completions.insert(stream_id);
+    a.pending_reset_completions.insert(stream_id);
+    a.reconfigs.insert(7, outgoing_reset(7, stream_id));
+    a.reconfigs.insert(8, outgoing_reset(8, stream_id));
+
+    for (rsn, result) in [
+        (7, ReconfigResult::SuccessPerformed),
+        (8, ReconfigResult::Denied),
+    ] {
+        let response: Box<dyn Param + Send + Sync> = Box::new(ParamReconfigResponse {
+            reconfig_response_sequence_number: rsn,
+            result,
+        });
+        a.handle_reconfig_param(&response, &mut vec![])?;
+    }
+
+    assert!(matches!(
+        a.poll(),
+        Some(Event::Stream(StreamEvent::ResetComplete { id })) if id == stream_id
+    ));
+    assert!(
+        a.open_stream(stream_id, PayloadProtocolIdentifier::Binary)
+            .is_ok(),
+        "ResetComplete promises that this stream ID has become reusable"
+    );
+    Ok(())
+}
+
+#[test]
+fn test_reconfig_response_does_not_ack_unsent_reciprocal() -> Result<()> {
+    let stream_id = 1;
+    let mut a = Association {
+        my_next_tsn: 1,
+        ..Default::default()
+    };
+    assert!(
+        a.create_stream(stream_id, false, PayloadProtocolIdentifier::Binary)
+            .is_some()
+    );
+
+    let request: Box<dyn Param + Send + Sync> = Box::new(ParamOutgoingResetRequest {
+        reconfig_request_sequence_number: 7,
+        reconfig_response_sequence_number: u32::MAX,
+        sender_last_tsn: a.peer_last_tsn,
+        stream_identifiers: vec![stream_id],
+    });
+    let mut reply = vec![];
+    a.handle_reconfig_param(&request, &mut reply)?;
+
+    let reciprocal_rsn = *a.reconfigs.keys().next().unwrap();
+    assert!(!reply.is_empty());
+    assert!(a.timers.get(Timer::Reconfig).is_none());
+
+    // The reciprocal is only queued in the reply and has not been transmitted.
+    // RFC 6525 H1 says to ignore a response for an RSN whose timer is not running.
+    let premature_response: Box<dyn Param + Send + Sync> = Box::new(ParamReconfigResponse {
+        reconfig_response_sequence_number: reciprocal_rsn,
+        result: ReconfigResult::SuccessPerformed,
+    });
+    a.handle_reconfig_param(&premature_response, &mut vec![])?;
+
+    let reset_complete = core::iter::from_fn(|| a.poll())
+        .filter(|event| {
+            matches!(
+                event,
+                Event::Stream(StreamEvent::ResetComplete { id }) if *id == stream_id
+            )
+        })
+        .count();
+    assert_eq!(
+        (a.reconfigs.contains_key(&reciprocal_rsn), reset_complete),
+        (true, 0),
+        "RFC 6525 H1 requires a response for an RSN whose timer is not running to be ignored"
+    );
+    Ok(())
+}
+
+#[test]
+fn test_outgoing_reset_does_not_ack_unsent_reciprocal_with_unrelated_timer() -> Result<()> {
+    let stream_id = 1;
+    let sent_rsn = 99;
+    let mut a = Association {
+        my_next_tsn: 1,
+        ..Default::default()
+    };
+    assert!(
+        a.create_stream(stream_id, false, PayloadProtocolIdentifier::Binary)
+            .is_some()
+    );
+
+    a.reconfigs.insert(sent_rsn, outgoing_reset(sent_rsn, 2));
+    a.timers
+        .start(Timer::Reconfig, Instant::now(), a.rto_mgr.get_rto());
+
+    // The global timer belongs to the already-sent request above. Processing
+    // this incoming request queues a distinct reciprocal, but does not send it.
+    let request: Box<dyn Param + Send + Sync> = Box::new(ParamOutgoingResetRequest {
+        reconfig_request_sequence_number: 7,
+        reconfig_response_sequence_number: u32::MAX,
+        sender_last_tsn: a.peer_last_tsn,
+        stream_identifiers: vec![stream_id],
+    });
+    let mut reply = vec![];
+    a.handle_reconfig_param(&request, &mut reply)?;
+
+    let reciprocal_rsn = *a.reconfigs.keys().find(|&&rsn| rsn != sent_rsn).unwrap();
+    assert!(!reply.is_empty());
+
+    let premature_ack: Box<dyn Param + Send + Sync> = Box::new(ParamOutgoingResetRequest {
+        reconfig_request_sequence_number: 8,
+        reconfig_response_sequence_number: reciprocal_rsn,
+        sender_last_tsn: a.peer_last_tsn,
+        stream_identifiers: vec![3],
+    });
+    a.handle_reconfig_param(&premature_ack, &mut vec![])?;
+
+    let reset_complete = core::iter::from_fn(|| a.poll())
+        .filter(|event| {
+            matches!(
+                event,
+                Event::Stream(StreamEvent::ResetComplete { id }) if *id == stream_id
+            )
+        })
+        .count();
+    assert_eq!(
+        (a.reconfigs.contains_key(&reciprocal_rsn), reset_complete),
+        (true, 0),
+        "a timer running for another RSN must not make an unsent reciprocal acknowledgeable"
+    );
+    Ok(())
+}
+
+#[test]
 fn test_create_forward_tsn_forward_one_abandoned() -> Result<()> {
     let mut a = Association {
         cumulative_tsn_ack_point: 9,

--- a/src/association/association_test.rs
+++ b/src/association/association_test.rs
@@ -1325,6 +1325,14 @@ fn test_successive_resets_preserve_each_unread_generation() -> Result<()> {
     }
     assert_eq!(finished, 1);
 
+    assert!(
+        core::iter::from_fn(|| a.poll()).any(|event| matches!(
+            event,
+            Event::Stream(StreamEvent::Readable { id }) if id == stream_id
+        )),
+        "generation B must advertise readability before its Finished event"
+    );
+
     let second = a.stream(stream_id)?.read()?.unwrap();
     let mut payload = [0; 5];
     assert_eq!(second.read(&mut payload)?, payload.len());
@@ -1434,6 +1442,123 @@ fn test_i_forward_tsn_skip_is_applied_to_reset_successor() -> Result<()> {
 }
 
 #[test]
+fn test_forward_tsn_during_in_progress_reset_applies_to_old_generation() -> Result<()> {
+    let stream_id = 1;
+    let mut a = Association {
+        state: AssociationState::Established,
+        peer_last_tsn: 0,
+        my_next_tsn: 1,
+        max_receive_buffer_size: 1024,
+        max_receive_message_size: 1024,
+        max_payload_size: 1200,
+        use_forward_tsn: true,
+        ..Default::default()
+    };
+    assert!(
+        a.create_stream(stream_id, false, PayloadProtocolIdentifier::Binary)
+            .is_some()
+    );
+    let reset: Box<dyn Param + Send + Sync> = Box::new(ParamOutgoingResetRequest {
+        reconfig_request_sequence_number: 7,
+        reconfig_response_sequence_number: u32::MAX,
+        sender_last_tsn: 1,
+        stream_identifiers: vec![stream_id],
+    });
+    a.handle_reconfig_param(&reset, &mut vec![])?;
+
+    // The reset has not reached its TSN boundary yet, so this skip belongs to
+    // the old generation even though the association-level cumulative TSN
+    // advances beyond that boundary.
+    a.handle_forward_tsn(&ChunkForwardTsn {
+        new_cumulative_tsn: 2,
+        streams: vec![ChunkForwardTsnStream {
+            identifier: stream_id,
+            sequence: 0,
+        }],
+    })?;
+
+    a.handle_data(&ChunkPayloadData {
+        tsn: 3,
+        stream_identifier: stream_id,
+        stream_sequence_number: 0,
+        beginning_fragment: true,
+        ending_fragment: true,
+        user_data: Bytes::from_static(b"new"),
+        ..Default::default()
+    })?;
+    let successor = a.stream(stream_id)?.read()?.unwrap();
+    let mut payload = [0; 3];
+    assert_eq!(successor.read(&mut payload)?, payload.len());
+    assert_eq!(&payload, b"new");
+    Ok(())
+}
+
+fn association_with_queued_second_reset() -> Result<Association> {
+    let mut a = association_with_retiring_boundary_data()?;
+    let second_reset: Box<dyn Param + Send + Sync> = Box::new(ParamOutgoingResetRequest {
+        reconfig_request_sequence_number: 8,
+        reconfig_response_sequence_number: u32::MAX,
+        sender_last_tsn: 2,
+        stream_identifiers: vec![1],
+    });
+    a.handle_reconfig_param(&second_reset, &mut vec![])?;
+    assert!(a.reconfig_requests.contains_key(&8));
+    Ok(a)
+}
+
+fn assert_generation_c_ssn_zero_is_readable(mut a: Association) -> Result<()> {
+    let old = a.stream(1)?.read()?.unwrap();
+    let mut payload = [0; 3];
+    assert_eq!(old.read(&mut payload)?, payload.len());
+    assert_eq!(&payload, b"old");
+
+    a.handle_data(&ChunkPayloadData {
+        tsn: 4,
+        stream_identifier: 1,
+        stream_sequence_number: 0,
+        beginning_fragment: true,
+        ending_fragment: true,
+        user_data: Bytes::from_static(b"gen-c"),
+        ..Default::default()
+    })?;
+    let generation_c = a.stream(1)?.read()?.unwrap();
+    let mut payload = [0; 5];
+    assert_eq!(generation_c.read(&mut payload)?, payload.len());
+    assert_eq!(&payload, b"gen-c");
+    Ok(())
+}
+
+#[test]
+fn test_forward_tsn_skip_is_scoped_to_queued_reset_generation() -> Result<()> {
+    let mut a = association_with_queued_second_reset()?;
+    a.handle_forward_tsn(&ChunkForwardTsn {
+        // TSN 2 is generation B's abandoned SSN 0. TSN 3 belongs to an
+        // unrelated stream, so the aggregate cumulative point cannot identify
+        // which stream generation the per-stream SSN describes.
+        new_cumulative_tsn: 3,
+        streams: vec![ChunkForwardTsnStream {
+            identifier: 1,
+            sequence: 0,
+        }],
+    })?;
+    assert_generation_c_ssn_zero_is_readable(a)
+}
+
+#[test]
+fn test_i_forward_tsn_skip_is_scoped_to_queued_reset_generation() -> Result<()> {
+    let mut a = association_with_queued_second_reset()?;
+    a.handle_i_forward_tsn(&ChunkIForwardTsn {
+        new_cumulative_tsn: 3,
+        streams: vec![ChunkIForwardTsnStream {
+            identifier: 1,
+            unordered: false,
+            mid: 0,
+        }],
+    })?;
+    assert_generation_c_ssn_zero_is_readable(a)
+}
+
+#[test]
 fn test_unread_retiring_stream_does_not_block_unrelated_events() -> Result<()> {
     let mut a = association_with_retiring_boundary_data()?;
     assert!(
@@ -1479,6 +1604,110 @@ fn test_stop_discards_unread_retiring_data_and_unblocks_finished() -> Result<()>
         a.poll(),
         Some(Event::Stream(StreamEvent::Finished { id: 1 }))
     ));
+    Ok(())
+}
+
+#[test]
+fn test_stop_does_not_reopen_read_half_on_deferred_successor() -> Result<()> {
+    let mut a = association_with_retiring_boundary_data()?;
+    a.handle_data(&ChunkPayloadData {
+        tsn: 2,
+        stream_identifier: 1,
+        stream_sequence_number: 0,
+        beginning_fragment: true,
+        ending_fragment: true,
+        user_data: Bytes::from_static(b"successor"),
+        ..Default::default()
+    })?;
+
+    let mut stream = a.stream(1)?;
+    stream.stop()?;
+    assert_eq!(stream.read().unwrap_err(), Error::ErrStreamClosed);
+    Ok(())
+}
+
+#[test]
+fn test_stop_before_reset_boundary_does_not_leave_finished_blocked() -> Result<()> {
+    let stream_id = 1;
+    let mut a = Association {
+        state: AssociationState::Established,
+        peer_last_tsn: 0,
+        my_next_tsn: 1,
+        max_receive_buffer_size: 1024,
+        max_receive_message_size: 1024,
+        max_payload_size: 1200,
+        ..Default::default()
+    };
+    for id in [stream_id, 2] {
+        assert!(
+            a.create_stream(id, false, PayloadProtocolIdentifier::Binary)
+                .is_some()
+        );
+    }
+
+    // TSN 2 is readable but cannot advance the cumulative point past missing
+    // TSN 1, leaving time for the application to stop the read half.
+    a.handle_data(&ChunkPayloadData {
+        tsn: 2,
+        stream_identifier: stream_id,
+        stream_sequence_number: 0,
+        beginning_fragment: true,
+        ending_fragment: true,
+        user_data: Bytes::from_static(b"discard"),
+        ..Default::default()
+    })?;
+    let reset: Box<dyn Param + Send + Sync> = Box::new(ParamOutgoingResetRequest {
+        reconfig_request_sequence_number: 7,
+        reconfig_response_sequence_number: u32::MAX,
+        sender_last_tsn: 2,
+        stream_identifiers: vec![stream_id],
+    });
+    a.handle_reconfig_param(&reset, &mut vec![])?;
+    a.stream(stream_id)?.stop()?;
+
+    a.handle_data(&ChunkPayloadData {
+        tsn: 1,
+        stream_identifier: 2,
+        stream_sequence_number: 0,
+        beginning_fragment: true,
+        ending_fragment: true,
+        user_data: Bytes::from_static(b"gap"),
+        ..Default::default()
+    })?;
+
+    assert!(a.stream(stream_id).is_err());
+    assert!(
+        core::iter::from_fn(|| a.poll()).any(|event| matches!(
+            event,
+            Event::Stream(StreamEvent::Finished { id }) if id == stream_id
+        )),
+        "a stopped read half cannot be left waiting for an impossible drain"
+    );
+    Ok(())
+}
+
+#[test]
+fn test_oversized_deferred_successor_is_rejected_before_old_read() -> Result<()> {
+    let mut a = association_with_retiring_boundary_data()?;
+    a.max_receive_message_size = 3;
+
+    let error = a
+        .handle_data(&ChunkPayloadData {
+            tsn: 2,
+            stream_identifier: 1,
+            stream_sequence_number: 0,
+            beginning_fragment: true,
+            ending_fragment: true,
+            user_data: Bytes::from_static(b"too-big"),
+            ..Default::default()
+        })
+        .unwrap_err();
+    assert_eq!(error, Error::ErrInboundPacketTooLarge);
+
+    let old = a.stream(1)?.read()?.unwrap();
+    let mut payload = [0; 3];
+    assert_eq!(old.read(&mut payload)?, payload.len());
+    assert_eq!(&payload, b"old");
     Ok(())
 }
 

--- a/src/association/association_test.rs
+++ b/src/association/association_test.rs
@@ -165,6 +165,33 @@ fn test_reconfig_retransmission_failure_is_terminal() {
 }
 
 #[test]
+fn test_ambiguous_reset_failure_keeps_existing_stream_quarantined() -> Result<()> {
+    let stream_id = 1;
+    let mut a = Association {
+        state: AssociationState::Established,
+        my_next_tsn: 1,
+        ..Default::default()
+    };
+    assert!(
+        a.create_stream(stream_id, false, PayloadProtocolIdentifier::Binary)
+            .is_some()
+    );
+
+    a.stream(stream_id)?.stop()?;
+    let _ = a.gather_outbound(Instant::now());
+    assert!(a.active_reconfig.is_some());
+
+    a.on_retransmission_failure(Timer::Reconfig);
+
+    assert!(a.failed_reset_streams.contains(&stream_id));
+    assert!(
+        !a.stream(stream_id)?.is_writable(),
+        "an unacknowledged reset may have succeeded at the peer, so old SSNs remain unsafe"
+    );
+    Ok(())
+}
+
+#[test]
 fn test_denied_reset_emits_terminal_event_and_remains_quarantined() -> Result<()> {
     let rsn = 7;
     let stream_id = 1;

--- a/src/association/association_test.rs
+++ b/src/association/association_test.rs
@@ -726,6 +726,32 @@ fn test_reset_completion_does_not_reopen_finished_write_half() -> Result<()> {
 }
 
 #[test]
+fn test_successful_outgoing_reset_restarts_stream_sequence_number() -> Result<()> {
+    let stream_id = 1;
+    let rsn = 7;
+    let mut a = Association::default();
+    assert!(
+        a.create_stream(stream_id, false, PayloadProtocolIdentifier::Binary)
+            .is_some()
+    );
+    a.streams.get_mut(&stream_id).unwrap().sequence_number = 9;
+    insert_active_reset(&mut a, rsn, stream_id);
+
+    let response: Box<dyn Param + Send + Sync> = Box::new(ParamReconfigResponse {
+        reconfig_response_sequence_number: rsn,
+        result: ReconfigResult::SuccessPerformed,
+    });
+    a.handle_reconfig_param(&response, &mut vec![])?;
+
+    assert_eq!(
+        a.streams.get(&stream_id).unwrap().sequence_number,
+        0,
+        "RFC 6525 section 5.2.7 H4 requires the affected outgoing SSN to reset"
+    );
+    Ok(())
+}
+
+#[test]
 fn test_only_one_buffered_reconfig_is_sent_when_timer_is_idle() {
     let mut a = Association {
         state: AssociationState::Established,

--- a/src/association/association_test.rs
+++ b/src/association/association_test.rs
@@ -1573,6 +1573,62 @@ fn test_retransmitted_forward_tsn_stays_with_reset_generation() -> Result<()> {
     assert_generation_c_ssn_zero_is_readable(a)
 }
 
+fn assert_successor_ssn_one_after_reused_forward_ssn(mut a: Association) -> Result<()> {
+    let old = a.stream(1)?.read()?.unwrap();
+    let mut payload = [0; 3];
+    assert_eq!(old.read(&mut payload)?, payload.len());
+    assert_eq!(&payload, b"old");
+
+    a.handle_data(&ChunkPayloadData {
+        tsn: 4,
+        stream_identifier: 1,
+        stream_sequence_number: 1,
+        beginning_fragment: true,
+        ending_fragment: true,
+        user_data: Bytes::from_static(b"gen-c"),
+        ..Default::default()
+    })?;
+    let generation_c = a
+        .stream(1)?
+        .read()?
+        .expect("generation C SSN 1 should follow its abandoned SSN 0");
+    let mut payload = [0; 5];
+    assert_eq!(generation_c.read(&mut payload)?, payload.len());
+    assert_eq!(&payload, b"gen-c");
+    Ok(())
+}
+
+#[test]
+fn test_successor_forward_tsn_can_reuse_reset_ssn() -> Result<()> {
+    let mut a = association_with_queued_second_reset()?;
+    for new_cumulative_tsn in [2, 3] {
+        a.handle_forward_tsn(&ChunkForwardTsn {
+            new_cumulative_tsn,
+            streams: vec![ChunkForwardTsnStream {
+                identifier: 1,
+                sequence: 0,
+            }],
+        })?;
+    }
+    assert_successor_ssn_one_after_reused_forward_ssn(a)
+}
+
+#[test]
+fn test_successor_i_forward_tsn_can_reuse_reset_mid() -> Result<()> {
+    let mut a = association_with_queued_second_reset()?;
+    for new_cumulative_tsn in [2, 3] {
+        a.handle_i_forward_tsn(&ChunkIForwardTsn {
+            new_cumulative_tsn,
+            streams: vec![ChunkIForwardTsnStream {
+                identifier: 1,
+                unordered: false,
+                mid: 0,
+            }],
+        })?;
+    }
+    assert_successor_ssn_one_after_reused_forward_ssn(a)
+}
+
 #[test]
 fn test_i_forward_tsn_skip_is_scoped_to_queued_reset_generation() -> Result<()> {
     let mut a = association_with_queued_second_reset()?;
@@ -1789,6 +1845,58 @@ fn test_i_forward_tsn_discards_deferred_unordered_fragment() -> Result<()> {
 }
 
 #[test]
+fn test_forward_tsn_releases_abandoned_deferred_fragment_credit_immediately() -> Result<()> {
+    let mut a = association_with_deferred_unordered_fragment()?;
+    let old_generation_bytes = a
+        .streams
+        .get(&1)
+        .unwrap()
+        .get_num_bytes_in_reassembly_queue() as u32;
+
+    a.handle_forward_tsn(&ChunkForwardTsn {
+        new_cumulative_tsn: 3,
+        streams: vec![],
+    })?;
+
+    assert_eq!(
+        a.get_my_receiver_window_credit(),
+        a.max_receive_buffer_size - old_generation_bytes,
+        "abandoned successor fragments must not hold receive-window credit until the old generation drains"
+    );
+    Ok(())
+}
+
+#[test]
+fn test_deferred_unordered_forward_tsn_updates_are_coalesced() -> Result<()> {
+    let mut a = association_with_retiring_boundary_data()?;
+    a.streams.get_mut(&1).unwrap().unordered = true;
+
+    for new_cumulative_tsn in 2..=9 {
+        a.handle_forward_tsn(&ChunkForwardTsn {
+            new_cumulative_tsn,
+            streams: vec![],
+        })?;
+    }
+
+    let updates = a.deferred_forward_tsns.get(&1).unwrap();
+    assert_eq!(
+        updates.len(),
+        1,
+        "newer unordered cumulative TSNs supersede older updates for the same generation"
+    );
+    assert!(matches!(
+        updates.front(),
+        Some(DeferredForwardTsn {
+            kind: DeferredForwardTsnKind::Unordered {
+                new_cumulative_tsn: 9
+            },
+            ..
+        })
+    ));
+    Ok(())
+}
+
+#[test]
 fn test_unread_retiring_stream_does_not_block_unrelated_events() -> Result<()> {
     let mut a = association_with_retiring_boundary_data()?;
     assert!(
@@ -1855,6 +1963,43 @@ fn test_stop_during_retirement_does_not_queue_duplicate_reset() -> Result<()> {
     );
     assert_eq!(a.reconfigs.len(), 1);
     Ok(())
+}
+
+fn assert_shutdown_during_retirement_allows_reuse(close: bool) -> Result<()> {
+    let mut a = association_with_retiring_boundary_data()?;
+    if close {
+        a.stream(1)?.close()?;
+    } else {
+        a.stream(1)?.stop()?;
+    }
+
+    let rsn = *a.reconfigs.keys().next().unwrap();
+    a.active_reconfig = Some(rsn);
+    let response: Box<dyn Param + Send + Sync> = Box::new(ParamReconfigResponse {
+        reconfig_response_sequence_number: rsn,
+        result: ReconfigResult::SuccessPerformed,
+    });
+    a.handle_reconfig_param(&response, &mut vec![])?;
+
+    assert!(
+        !a.streams.contains_key(&1),
+        "a completed reciprocal reset must remove the locally shut down stream"
+    );
+    assert!(
+        a.open_stream(1, PayloadProtocolIdentifier::Binary).is_ok(),
+        "ResetComplete must make the retired stream id reusable"
+    );
+    Ok(())
+}
+
+#[test]
+fn test_stop_during_retirement_allows_reuse_after_reset_complete() -> Result<()> {
+    assert_shutdown_during_retirement_allows_reuse(false)
+}
+
+#[test]
+fn test_close_during_retirement_allows_reuse_after_reset_complete() -> Result<()> {
+    assert_shutdown_during_retirement_allows_reuse(true)
 }
 
 #[test]
@@ -2003,6 +2148,40 @@ fn test_duplicate_stream_ids_retire_only_one_generation() -> Result<()> {
             .collect::<Vec<_>>(),
         vec![stream_id]
     );
+    Ok(())
+}
+
+#[test]
+fn test_reconfig_rejects_two_outgoing_resets_without_mutation() -> Result<()> {
+    let mut a = association_with_retiring_boundary_data()?;
+    let boundaries_before = a.retiring_streams.get(&1).unwrap().len();
+    let completions_before = a.pending_reset_completions.0.get(&1).copied();
+    let reconfigs_before = a.reconfigs.len();
+
+    let reconfig = ChunkReconfig {
+        param_a: Some(Box::new(ParamOutgoingResetRequest {
+            reconfig_request_sequence_number: 8,
+            reconfig_response_sequence_number: u32::MAX,
+            sender_last_tsn: a.peer_last_tsn,
+            stream_identifiers: vec![1],
+        })),
+        param_b: Some(Box::new(ParamOutgoingResetRequest {
+            reconfig_request_sequence_number: 9,
+            reconfig_response_sequence_number: u32::MAX,
+            sender_last_tsn: a.peer_last_tsn,
+            stream_identifiers: vec![1],
+        })),
+    };
+    let packet = a.create_packet(vec![Box::new(reconfig)]);
+    let result = a.handle_chunk(&packet, &packet.chunks[0], Instant::now());
+
+    assert!(result.is_err(), "two Outgoing Reset parameters are invalid");
+    assert_eq!(a.retiring_streams.get(&1).unwrap().len(), boundaries_before);
+    assert_eq!(
+        a.pending_reset_completions.0.get(&1).copied(),
+        completions_before
+    );
+    assert_eq!(a.reconfigs.len(), reconfigs_before);
     Ok(())
 }
 
@@ -2203,6 +2382,38 @@ fn test_empty_reset_stream_list_resets_all_streams() -> Result<()> {
         .unwrap_or_default();
     reciprocal_ids.sort_unstable();
     assert_eq!(reciprocal_ids, vec![1, 2]);
+    Ok(())
+}
+
+#[test]
+fn test_reset_all_reciprocal_fits_reconfig_chunk_length() -> Result<()> {
+    let mut a = Association {
+        my_next_tsn: 1,
+        ..Default::default()
+    };
+    for stream_id in 0..32_758u32 {
+        assert!(
+            a.create_stream(
+                stream_id as StreamId,
+                false,
+                PayloadProtocolIdentifier::Binary,
+            )
+            .is_some()
+        );
+    }
+
+    let request: Box<dyn Param + Send + Sync> = Box::new(ParamOutgoingResetRequest {
+        reconfig_request_sequence_number: 7,
+        reconfig_response_sequence_number: u32::MAX,
+        sender_last_tsn: a.peer_last_tsn,
+        stream_identifiers: vec![],
+    });
+    let mut reply = vec![];
+    a.handle_reconfig_param(&request, &mut reply)?;
+
+    for packet in reply {
+        packet.marshal()?;
+    }
     Ok(())
 }
 

--- a/src/association/association_test.rs
+++ b/src/association/association_test.rs
@@ -644,6 +644,183 @@ fn test_peer_recreated_quarantined_stream_is_not_writable() -> Result<()> {
 }
 
 #[test]
+fn test_only_one_buffered_reconfig_is_sent_when_timer_is_idle() {
+    let mut a = Association {
+        state: AssociationState::Established,
+        ..Default::default()
+    };
+
+    for (rsn, stream_id) in [(7, 1), (8, 2)] {
+        let c = outgoing_reset(rsn, stream_id);
+        a.reconfigs.insert(rsn, c.clone());
+        a.unsent_reconfigs.insert(rsn);
+        let packet = a.create_packet(vec![Box::new(c)]);
+        a.control_queue.push_back(packet);
+    }
+    assert!(a.timers.get(Timer::Reconfig).is_none());
+
+    assert!(a.poll_transmit(Instant::now()).is_some());
+    assert_eq!(
+        a.unsent_reconfigs.len(),
+        1,
+        "RFC 6525 permits only one reconfiguration request in flight"
+    );
+}
+
+#[test]
+fn test_in_progress_keeps_later_request_buffered() -> Result<()> {
+    let mut a = Association {
+        state: AssociationState::Established,
+        ..Default::default()
+    };
+
+    a.reconfigs.insert(7, outgoing_reset(7, 1));
+    let buffered = outgoing_reset(8, 2);
+    a.reconfigs.insert(8, buffered.clone());
+    a.unsent_reconfigs.insert(8);
+    let packet = a.create_packet(vec![Box::new(buffered)]);
+    a.control_queue.push_back(packet);
+    a.timers
+        .start(Timer::Reconfig, Instant::now(), a.rto_mgr.get_rto());
+
+    let response: Box<dyn Param + Send + Sync> = Box::new(ParamReconfigResponse {
+        reconfig_response_sequence_number: 7,
+        result: ReconfigResult::InProgress,
+    });
+    a.handle_reconfig_param(&response, &mut vec![])?;
+    assert!(a.reconfigs.contains_key(&7));
+
+    let _ = a.poll_transmit(Instant::now());
+    assert!(
+        a.unsent_reconfigs.contains(&8),
+        "InProgress leaves the current request in flight, so the next must stay buffered"
+    );
+    Ok(())
+}
+
+#[test]
+fn test_local_reset_stays_queued_while_reconfig_timer_runs() -> Result<()> {
+    let mut a = Association {
+        state: AssociationState::Established,
+        my_next_tsn: 1,
+        ..Default::default()
+    };
+
+    a.reconfigs.insert(7, outgoing_reset(7, 1));
+    a.timers
+        .start(Timer::Reconfig, Instant::now(), a.rto_mgr.get_rto());
+    a.send_reset_request(2)?;
+
+    let _ = a.poll_transmit(Instant::now());
+    assert_eq!(
+        a.reconfigs.len(),
+        1,
+        "a locally initiated reset must remain queued while another request is in flight"
+    );
+    Ok(())
+}
+
+#[test]
+fn test_retransmission_does_not_send_buffered_reconfigs() {
+    let mut a = Association {
+        state: AssociationState::Established,
+        ..Default::default()
+    };
+
+    let active = outgoing_reset(7, 1);
+    let buffered = outgoing_reset(8, 2);
+    a.reconfigs.insert(7, active);
+    a.reconfigs.insert(8, buffered.clone());
+    a.unsent_reconfigs.insert(8);
+    a.control_queue
+        .push_back(a.create_packet(vec![Box::new(buffered)]));
+    a.timers
+        .start(Timer::Reconfig, Instant::now(), a.rto_mgr.get_rto());
+    a.will_retransmit_reconfig = true;
+
+    let (packets, _) = a.gather_outbound(Instant::now());
+    assert_eq!(
+        packets.len(),
+        1,
+        "retransmission must include only the request associated with the running timer"
+    );
+}
+
+#[test]
+fn test_older_completion_does_not_make_newer_generation_writable() -> Result<()> {
+    let stream_id = 1;
+    let mut a = Association::default();
+
+    a.pending_reset_completions.insert(stream_id);
+    a.pending_reset_completions.insert(stream_id);
+    a.reconfigs.insert(7, outgoing_reset(7, stream_id));
+    a.reconfigs.insert(8, outgoing_reset(8, stream_id));
+    a.unsent_reconfigs.insert(8);
+    a.timers
+        .start(Timer::Reconfig, Instant::now(), a.rto_mgr.get_rto());
+
+    assert!(a.get_or_create_stream(stream_id).is_some());
+    assert!(!a.stream(stream_id)?.is_writable());
+
+    let response: Box<dyn Param + Send + Sync> = Box::new(ParamReconfigResponse {
+        reconfig_response_sequence_number: 7,
+        result: ReconfigResult::SuccessPerformed,
+    });
+    a.handle_reconfig_param(&response, &mut vec![])?;
+
+    assert!(a.reconfigs.contains_key(&8));
+    assert!(
+        !a.stream(stream_id)?.is_writable(),
+        "an older success cannot release the newer generation's outgoing quarantine"
+    );
+    Ok(())
+}
+
+#[test]
+fn test_stale_completion_does_not_override_newer_denial() -> Result<()> {
+    let stream_id = 1;
+    let mut a = Association::default();
+
+    a.pending_reset_completions.insert(stream_id);
+    a.reconfigs.insert(7, outgoing_reset(7, stream_id));
+
+    let success: Box<dyn Param + Send + Sync> = Box::new(ParamReconfigResponse {
+        reconfig_response_sequence_number: 7,
+        result: ReconfigResult::SuccessPerformed,
+    });
+    a.handle_reconfig_param(&success, &mut vec![])?;
+
+    // Before the application polls generation 7's completion, the peer opens
+    // and uses generation 8, then resets it. Its nonzero outgoing sequence
+    // means a denied reciprocal reset must quarantine the id.
+    assert!(a.get_or_create_stream(stream_id).is_some());
+    a.streams.get_mut(&stream_id).unwrap().sequence_number = 1;
+    a.unregister_stream(stream_id, true);
+    a.reconfigs.insert(8, outgoing_reset(8, stream_id));
+    a.timers
+        .start(Timer::Reconfig, Instant::now(), a.rto_mgr.get_rto());
+
+    let denied: Box<dyn Param + Send + Sync> = Box::new(ParamReconfigResponse {
+        reconfig_response_sequence_number: 8,
+        result: ReconfigResult::Denied,
+    });
+    a.handle_reconfig_param(&denied, &mut vec![])?;
+
+    // Polling the stale completion must not resurrect reuse permission after
+    // generation 8 has already failed.
+    assert!(matches!(
+        a.poll(),
+        Some(Event::Stream(StreamEvent::ResetComplete { id })) if id == stream_id
+    ));
+
+    assert!(matches!(
+        a.open_stream(stream_id, PayloadProtocolIdentifier::Binary),
+        Err(Error::ErrStreamResetPending)
+    ));
+    Ok(())
+}
+
+#[test]
 fn test_create_forward_tsn_forward_one_abandoned() -> Result<()> {
     let mut a = Association {
         cumulative_tsn_ack_point: 9,

--- a/src/association/association_test.rs
+++ b/src/association/association_test.rs
@@ -1097,6 +1097,149 @@ fn test_reciprocal_reset_covers_preexisting_pending_data() -> Result<()> {
 }
 
 #[test]
+fn test_data_above_deferred_reset_boundary_waits_for_new_generation() -> Result<()> {
+    let stream_id = 1;
+    let mut a = Association {
+        state: AssociationState::Established,
+        peer_last_tsn: 0,
+        my_next_tsn: 1,
+        max_receive_buffer_size: 1024,
+        max_receive_message_size: 1024,
+        max_payload_size: 1200,
+        ..Default::default()
+    };
+    assert!(
+        a.create_stream(stream_id, false, PayloadProtocolIdentifier::Binary)
+            .is_some()
+    );
+
+    let request: Box<dyn Param + Send + Sync> = Box::new(ParamOutgoingResetRequest {
+        reconfig_request_sequence_number: 7,
+        reconfig_response_sequence_number: u32::MAX,
+        sender_last_tsn: 1,
+        stream_identifiers: vec![stream_id],
+    });
+    a.handle_reconfig_param(&request, &mut vec![])?;
+    assert!(a.reconfig_requests.contains_key(&7));
+
+    // TSN 2 belongs to the post-reset generation, but arrives while TSN 1 is
+    // still missing and the reset therefore remains InProgress.
+    a.handle_data(&ChunkPayloadData {
+        tsn: 2,
+        stream_identifier: stream_id,
+        stream_sequence_number: 0,
+        beginning_fragment: true,
+        ending_fragment: true,
+        user_data: Bytes::from_static(b"new"),
+        ..Default::default()
+    })?;
+
+    assert!(
+        a.poll().is_none(),
+        "post-reset DATA must not notify the old stream generation"
+    );
+    assert!(
+        a.stream(stream_id)?.read()?.is_none(),
+        "post-reset DATA must not be readable before the reset boundary arrives"
+    );
+
+    // Once TSN 1 arrives, the old generation is reset and held TSN 2 is
+    // delivered into a newly created generation whose SSN starts at zero.
+    a.handle_data(&ChunkPayloadData {
+        tsn: 1,
+        stream_identifier: stream_id,
+        stream_sequence_number: 0,
+        beginning_fragment: true,
+        ending_fragment: true,
+        user_data: Bytes::from_static(b"old"),
+        ..Default::default()
+    })?;
+
+    let message = a.stream(stream_id)?.read()?.unwrap();
+    let mut payload = [0; 3];
+    assert_eq!(message.read(&mut payload)?, payload.len());
+    assert_eq!(&payload, b"new");
+    Ok(())
+}
+
+#[test]
+fn test_empty_reset_stream_list_resets_all_streams() -> Result<()> {
+    let mut a = Association {
+        my_next_tsn: 1,
+        ..Default::default()
+    };
+    for stream_id in [1, 2] {
+        assert!(
+            a.create_stream(stream_id, false, PayloadProtocolIdentifier::Binary)
+                .is_some()
+        );
+    }
+
+    let request: Box<dyn Param + Send + Sync> = Box::new(ParamOutgoingResetRequest {
+        reconfig_request_sequence_number: 7,
+        reconfig_response_sequence_number: u32::MAX,
+        sender_last_tsn: a.peer_last_tsn,
+        stream_identifiers: vec![],
+    });
+    let mut reply = vec![];
+    a.handle_reconfig_param(&request, &mut reply)?;
+
+    assert!(
+        a.streams.is_empty(),
+        "an omitted stream list means all streams"
+    );
+    let mut reciprocal_ids = a
+        .reconfigs
+        .values()
+        .next()
+        .map(Association::reconfig_stream_ids)
+        .unwrap_or_default();
+    reciprocal_ids.sort_unstable();
+    assert_eq!(reciprocal_ids, vec![1, 2]);
+    Ok(())
+}
+
+#[test]
+fn test_blocked_reconfig_does_not_allow_later_rsn_to_overtake() {
+    let mut a = Association {
+        state: AssociationState::Established,
+        my_next_tsn: 1,
+        cwnd: 0,
+        rwnd: 0,
+        mtu: 1400,
+        ..Default::default()
+    };
+    a.pending_queue.push(ChunkPayloadData {
+        stream_identifier: 1,
+        beginning_fragment: true,
+        ending_fragment: true,
+        user_data: Bytes::from_static(b"pending"),
+        ..Default::default()
+    });
+    a.inflight_queue.push_no_check(ChunkPayloadData {
+        tsn: 0,
+        stream_identifier: 2,
+        user_data: Bytes::from_static(b"inflight"),
+        ..Default::default()
+    });
+    insert_queued_reset(&mut a, 7, 1);
+    insert_queued_reset(&mut a, 8, 2);
+
+    let _ = a.gather_outbound(Instant::now());
+    assert!(
+        a.active_reconfig.is_none(),
+        "RSN 8 must not overtake RSN 7 while RSN 7 waits for its DATA boundary"
+    );
+    assert_eq!(a.control_queue.len(), 2);
+
+    a.cwnd = 1400;
+    a.rwnd = 1400;
+    let _ = a.gather_outbound(Instant::now());
+    assert_eq!(a.active_reconfig, Some(7));
+    assert_eq!(a.control_queue.len(), 1);
+}
+
+#[test]
 fn test_retransmission_does_not_send_buffered_reconfigs() {
     let mut a = Association {
         state: AssociationState::Established,

--- a/src/association/association_test.rs
+++ b/src/association/association_test.rs
@@ -170,6 +170,13 @@ fn test_denied_reset_remains_quarantined_without_terminal_event() -> Result<()> 
         a.pending_reset_completions.contains(&stream_id),
         "a failed reset needs either a terminal event or continued quarantine"
     );
+    assert!(
+        matches!(
+            a.open_stream(stream_id, PayloadProtocolIdentifier::Binary),
+            Err(Error::ErrStreamResetPending)
+        ),
+        "the quarantine must prevent the failed stream ID from being reused"
+    );
     Ok(())
 }
 
@@ -249,6 +256,80 @@ fn test_reset_complete_preserves_generations_through_responses() -> Result<()> {
 }
 
 #[test]
+fn test_overlapping_generations_success_then_denied_reports_success() -> Result<()> {
+    let stream_id = 1;
+    let mut a = Association::default();
+
+    a.pending_reset_completions.insert(stream_id);
+    a.pending_reset_completions.insert(stream_id);
+    a.reconfigs.insert(7, outgoing_reset(7, stream_id));
+    a.reconfigs.insert(8, outgoing_reset(8, stream_id));
+
+    for (rsn, result) in [
+        (7, ReconfigResult::SuccessPerformed),
+        (8, ReconfigResult::Denied),
+    ] {
+        let response: Box<dyn Param + Send + Sync> = Box::new(ParamReconfigResponse {
+            reconfig_response_sequence_number: rsn,
+            result,
+        });
+        a.handle_reconfig_param(&response, &mut vec![])?;
+    }
+
+    let reset_complete = core::iter::from_fn(|| a.poll())
+        .filter(|event| {
+            matches!(
+                event,
+                Event::Stream(StreamEvent::ResetComplete { id }) if *id == stream_id
+            )
+        })
+        .count();
+
+    assert_eq!(
+        reset_complete, 1,
+        "the successful generation still needs its ResetComplete"
+    );
+    Ok(())
+}
+
+#[test]
+fn test_overlapping_generations_denied_then_success_reports_only_success() -> Result<()> {
+    let stream_id = 1;
+    let mut a = Association::default();
+
+    a.pending_reset_completions.insert(stream_id);
+    a.pending_reset_completions.insert(stream_id);
+    a.reconfigs.insert(7, outgoing_reset(7, stream_id));
+    a.reconfigs.insert(8, outgoing_reset(8, stream_id));
+
+    for (rsn, result) in [
+        (7, ReconfigResult::Denied),
+        (8, ReconfigResult::SuccessPerformed),
+    ] {
+        let response: Box<dyn Param + Send + Sync> = Box::new(ParamReconfigResponse {
+            reconfig_response_sequence_number: rsn,
+            result,
+        });
+        a.handle_reconfig_param(&response, &mut vec![])?;
+    }
+
+    let reset_complete = core::iter::from_fn(|| a.poll())
+        .filter(|event| {
+            matches!(
+                event,
+                Event::Stream(StreamEvent::ResetComplete { id }) if *id == stream_id
+            )
+        })
+        .count();
+
+    assert_eq!(
+        reset_complete, 1,
+        "the denied generation must not inherit a later successful completion"
+    );
+    Ok(())
+}
+
+#[test]
 fn test_outgoing_reset_implicitly_acknowledges_pending_request() -> Result<()> {
     let local_rsn = 7;
     let stream_id = 1;
@@ -276,6 +357,60 @@ fn test_outgoing_reset_implicitly_acknowledges_pending_request() -> Result<()> {
     assert!(
         a.timers.get(Timer::Reconfig).is_none(),
         "the timer must stop after the final in-flight request is acknowledged"
+    );
+    Ok(())
+}
+
+#[test]
+fn test_outgoing_reset_does_not_ack_unsent_reciprocal() -> Result<()> {
+    let stream_id = 1;
+    let mut a = Association {
+        my_next_tsn: 1,
+        ..Default::default()
+    };
+    assert!(
+        a.create_stream(stream_id, false, PayloadProtocolIdentifier::Binary)
+            .is_some()
+    );
+
+    // Handling this request queues a reciprocal Outgoing Reset Request in
+    // `reply`, but it has not been transmitted and its timer is not running.
+    let request: Box<dyn Param + Send + Sync> = Box::new(ParamOutgoingResetRequest {
+        reconfig_request_sequence_number: 7,
+        reconfig_response_sequence_number: u32::MAX,
+        sender_last_tsn: a.peer_last_tsn,
+        stream_identifiers: vec![stream_id],
+    });
+    let mut reply = vec![];
+    a.handle_reconfig_param(&request, &mut reply)?;
+
+    let reciprocal_rsn = *a.reconfigs.keys().next().unwrap();
+    assert!(!reply.is_empty());
+    assert!(a.timers.get(Timer::Reconfig).is_none());
+
+    // RFC 6525 section 5.2.2 E1 only acknowledges a request for which the
+    // Re-configuration Timer is running. A peer must not be able to pre-ack
+    // the queued reciprocal before the application polls it for transmission.
+    let premature_ack: Box<dyn Param + Send + Sync> = Box::new(ParamOutgoingResetRequest {
+        reconfig_request_sequence_number: 8,
+        reconfig_response_sequence_number: reciprocal_rsn,
+        sender_last_tsn: a.peer_last_tsn,
+        stream_identifiers: vec![],
+    });
+    a.handle_reconfig_param(&premature_ack, &mut vec![])?;
+
+    let reset_complete = core::iter::from_fn(|| a.poll())
+        .filter(|event| {
+            matches!(
+                event,
+                Event::Stream(StreamEvent::ResetComplete { id }) if *id == stream_id
+            )
+        })
+        .count();
+    assert_eq!(
+        (a.reconfigs.contains_key(&reciprocal_rsn), reset_complete),
+        (true, 0),
+        "an unsent reciprocal must remain pending and cannot complete a reset"
     );
     Ok(())
 }

--- a/src/association/association_test.rs
+++ b/src/association/association_test.rs
@@ -1,3 +1,4 @@
+use crate::chunk::chunk_i_forward_tsn::ChunkIForwardTsnStream;
 use crate::chunk::{Chunk, chunk_init::ChunkInit};
 use crate::config::generate_snap_token;
 
@@ -1245,6 +1246,238 @@ fn test_reset_boundary_data_remains_readable_before_finished() -> Result<()> {
             Event::Stream(StreamEvent::Finished { id }) if *id == stream_id
         )),
         Some(Event::Stream(StreamEvent::Finished { id })) if id == stream_id
+    ));
+    Ok(())
+}
+
+#[test]
+fn test_successive_resets_preserve_each_unread_generation() -> Result<()> {
+    let stream_id = 1;
+    let mut a = Association {
+        state: AssociationState::Established,
+        peer_last_tsn: 0,
+        my_next_tsn: 1,
+        max_receive_buffer_size: 1024,
+        max_receive_message_size: 1024,
+        max_payload_size: 1200,
+        ..Default::default()
+    };
+    assert!(
+        a.create_stream(stream_id, false, PayloadProtocolIdentifier::Binary)
+            .is_some()
+    );
+
+    let first_reset: Box<dyn Param + Send + Sync> = Box::new(ParamOutgoingResetRequest {
+        reconfig_request_sequence_number: 7,
+        reconfig_response_sequence_number: u32::MAX,
+        sender_last_tsn: 1,
+        stream_identifiers: vec![stream_id],
+    });
+    a.handle_reconfig_param(&first_reset, &mut vec![])?;
+    a.handle_data(&ChunkPayloadData {
+        tsn: 1,
+        stream_identifier: stream_id,
+        stream_sequence_number: 0,
+        beginning_fragment: true,
+        ending_fragment: true,
+        user_data: Bytes::from_static(b"gen-a"),
+        ..Default::default()
+    })?;
+
+    // The successor arrives while generation A is still unread.
+    a.handle_data(&ChunkPayloadData {
+        tsn: 2,
+        stream_identifier: stream_id,
+        stream_sequence_number: 0,
+        beginning_fragment: true,
+        ending_fragment: true,
+        user_data: Bytes::from_static(b"gen-b"),
+        ..Default::default()
+    })?;
+    let second_reset: Box<dyn Param + Send + Sync> = Box::new(ParamOutgoingResetRequest {
+        reconfig_request_sequence_number: 8,
+        reconfig_response_sequence_number: u32::MAX,
+        sender_last_tsn: 2,
+        stream_identifiers: vec![stream_id],
+    });
+    a.handle_reconfig_param(&second_reset, &mut vec![])?;
+
+    // Model successful reciprocal handshakes for both reset generations.
+    a.emit_reset_complete([stream_id]);
+    a.emit_reset_complete([stream_id]);
+
+    let first = a.stream(stream_id)?.read()?.unwrap();
+    let mut payload = [0; 5];
+    assert_eq!(first.read(&mut payload)?, payload.len());
+    assert_eq!(&payload, b"gen-a");
+
+    let mut finished = 0;
+    let mut reset_complete = 0;
+    while reset_complete == 0 {
+        match a.poll() {
+            Some(Event::Stream(StreamEvent::Finished { id })) if id == stream_id => finished += 1,
+            Some(Event::Stream(StreamEvent::ResetComplete { id })) if id == stream_id => {
+                reset_complete += 1;
+            }
+            Some(_) => {}
+            None => panic!("generation A terminal event was blocked by unread generation B"),
+        }
+    }
+    assert_eq!(finished, 1);
+
+    let second = a.stream(stream_id)?.read()?.unwrap();
+    let mut payload = [0; 5];
+    assert_eq!(second.read(&mut payload)?, payload.len());
+    assert_eq!(&payload, b"gen-b");
+    assert!(
+        a.stream(stream_id).is_err(),
+        "generation B was also reset and must retire after it is drained"
+    );
+
+    while let Some(event) = a.poll() {
+        match event {
+            Event::Stream(StreamEvent::Finished { id }) if id == stream_id => finished += 1,
+            Event::Stream(StreamEvent::ResetComplete { id }) if id == stream_id => {
+                reset_complete += 1;
+            }
+            _ => {}
+        }
+    }
+    assert_eq!(finished, 2);
+    assert_eq!(reset_complete, 2);
+    Ok(())
+}
+
+fn association_with_retiring_boundary_data() -> Result<Association> {
+    let stream_id = 1;
+    let mut a = Association {
+        state: AssociationState::Established,
+        peer_last_tsn: 0,
+        my_next_tsn: 1,
+        max_receive_buffer_size: 1024,
+        max_receive_message_size: 1024,
+        max_payload_size: 1200,
+        use_forward_tsn: true,
+        ..Default::default()
+    };
+    assert!(
+        a.create_stream(stream_id, false, PayloadProtocolIdentifier::Binary)
+            .is_some()
+    );
+    let reset: Box<dyn Param + Send + Sync> = Box::new(ParamOutgoingResetRequest {
+        reconfig_request_sequence_number: 7,
+        reconfig_response_sequence_number: u32::MAX,
+        sender_last_tsn: 1,
+        stream_identifiers: vec![stream_id],
+    });
+    a.handle_reconfig_param(&reset, &mut vec![])?;
+    a.handle_data(&ChunkPayloadData {
+        tsn: 1,
+        stream_identifier: stream_id,
+        stream_sequence_number: 0,
+        beginning_fragment: true,
+        ending_fragment: true,
+        user_data: Bytes::from_static(b"old"),
+        ..Default::default()
+    })?;
+    Ok(a)
+}
+
+fn assert_successor_ssn_one_is_readable(mut a: Association) -> Result<()> {
+    let stream_id = 1;
+    let old = a.stream(stream_id)?.read()?.unwrap();
+    let mut payload = [0; 3];
+    assert_eq!(old.read(&mut payload)?, payload.len());
+    assert_eq!(&payload, b"old");
+
+    a.handle_data(&ChunkPayloadData {
+        tsn: 3,
+        stream_identifier: stream_id,
+        stream_sequence_number: 1,
+        beginning_fragment: true,
+        ending_fragment: true,
+        user_data: Bytes::from_static(b"new"),
+        ..Default::default()
+    })?;
+    let successor = a.stream(stream_id)?.read()?.unwrap();
+    let mut payload = [0; 3];
+    assert_eq!(successor.read(&mut payload)?, payload.len());
+    assert_eq!(&payload, b"new");
+    Ok(())
+}
+
+#[test]
+fn test_forward_tsn_skip_is_applied_to_reset_successor() -> Result<()> {
+    let mut a = association_with_retiring_boundary_data()?;
+    a.handle_forward_tsn(&ChunkForwardTsn {
+        new_cumulative_tsn: 2,
+        streams: vec![ChunkForwardTsnStream {
+            identifier: 1,
+            sequence: 0,
+        }],
+    })?;
+    assert_successor_ssn_one_is_readable(a)
+}
+
+#[test]
+fn test_i_forward_tsn_skip_is_applied_to_reset_successor() -> Result<()> {
+    let mut a = association_with_retiring_boundary_data()?;
+    a.handle_i_forward_tsn(&ChunkIForwardTsn {
+        new_cumulative_tsn: 2,
+        streams: vec![ChunkIForwardTsnStream {
+            identifier: 1,
+            unordered: false,
+            mid: 0,
+        }],
+    })?;
+    assert_successor_ssn_one_is_readable(a)
+}
+
+#[test]
+fn test_unread_retiring_stream_does_not_block_unrelated_events() -> Result<()> {
+    let mut a = association_with_retiring_boundary_data()?;
+    assert!(
+        a.create_stream(2, false, PayloadProtocolIdentifier::Binary)
+            .is_some()
+    );
+
+    assert!(
+        core::iter::from_fn(|| a.poll())
+            .any(|event| matches!(event, Event::Stream(StreamEvent::Readable { id: 1 })))
+    );
+    assert!(a.poll().is_none(), "stream 1 Finished should still wait");
+
+    a.handle_data(&ChunkPayloadData {
+        tsn: 2,
+        stream_identifier: 2,
+        stream_sequence_number: 0,
+        beginning_fragment: true,
+        ending_fragment: true,
+        user_data: Bytes::from_static(b"other"),
+        ..Default::default()
+    })?;
+
+    assert!(matches!(a.poll(), Some(Event::DatagramReceived)));
+    assert!(matches!(
+        a.poll(),
+        Some(Event::Stream(StreamEvent::Readable { id: 2 }))
+    ));
+    Ok(())
+}
+
+#[test]
+fn test_stop_discards_unread_retiring_data_and_unblocks_finished() -> Result<()> {
+    let mut a = association_with_retiring_boundary_data()?;
+    assert!(
+        core::iter::from_fn(|| a.poll())
+            .any(|event| matches!(event, Event::Stream(StreamEvent::Readable { id: 1 })))
+    );
+    assert!(a.poll().is_none(), "Finished should wait for old DATA");
+
+    a.stream(1)?.stop()?;
+    assert!(matches!(
+        a.poll(),
+        Some(Event::Stream(StreamEvent::Finished { id: 1 }))
     ));
     Ok(())
 }

--- a/src/association/association_test.rs
+++ b/src/association/association_test.rs
@@ -1811,8 +1811,8 @@ fn assert_abandoned_unordered_fragment_is_discarded(mut a: Association) -> Resul
     assert_eq!(
         a.streams
             .get(&1)
-            .unwrap()
-            .get_num_bytes_in_reassembly_queue(),
+            .map(StreamState::get_num_bytes_in_reassembly_queue)
+            .unwrap_or_default(),
         0,
         "an abandoned partial unordered message must not survive replay"
     );
@@ -2374,14 +2374,24 @@ fn test_empty_reset_stream_list_resets_all_streams() -> Result<()> {
         a.streams.is_empty(),
         "an omitted stream list means all streams"
     );
-    let mut reciprocal_ids = a
+    let reciprocal_ids = a
         .reconfigs
         .values()
         .next()
         .map(Association::reconfig_stream_ids)
         .unwrap_or_default();
-    reciprocal_ids.sort_unstable();
-    assert_eq!(reciprocal_ids, vec![1, 2]);
+    assert!(
+        reciprocal_ids.is_empty(),
+        "reset-all must remain compact on the wire"
+    );
+    let mut completion_ids = a
+        .reconfig_reset_streams
+        .values()
+        .next()
+        .cloned()
+        .unwrap_or_default();
+    completion_ids.sort_unstable();
+    assert_eq!(completion_ids, vec![1, 2]);
     Ok(())
 }
 

--- a/src/association/mod.rs
+++ b/src/association/mod.rs
@@ -2036,30 +2036,61 @@ impl Association {
         }
     }
 
+    fn deferred_forward_tsn_is_ready(
+        &self,
+        stream_identifier: StreamId,
+        update: DeferredForwardTsn,
+    ) -> bool {
+        match update.kind {
+            DeferredForwardTsnKind::Ordered { last_ssn, .. } => {
+                self.streams.get(&stream_identifier).is_some_and(|stream| {
+                    stream
+                        .reassembly_queue
+                        .can_apply_forward_tsn_for_ordered_bounded(last_ssn, self.peer_last_tsn)
+                })
+            }
+            DeferredForwardTsnKind::Unordered { .. } => true,
+        }
+    }
+
     fn apply_deferred_forward_tsns(&mut self, stream_identifier: StreamId) {
         if !self.streams.contains_key(&stream_identifier) {
             return;
         }
 
         let boundary = self.current_reset_boundary(stream_identifier);
-        let ready: Vec<DeferredForwardTsn> = self
-            .deferred_forward_tsns
-            .get(&stream_identifier)
-            .into_iter()
-            .flatten()
-            .filter(|update| update.generation_boundary == boundary)
-            .copied()
-            .collect();
+        let Some(updates) = self.deferred_forward_tsns.get(&stream_identifier) else {
+            return;
+        };
+        let mut removals = Vec::with_capacity(updates.len());
+        let mut ready = vec![];
+        for update in updates {
+            let remove = update.generation_boundary == boundary
+                && self.deferred_forward_tsn_is_ready(stream_identifier, *update);
+            removals.push(remove);
+            if remove {
+                ready.push(*update);
+            }
+        }
 
         if ready.is_empty() {
             return;
         }
 
+        let mut index = 0;
         if let Some(updates) = self.deferred_forward_tsns.get_mut(&stream_identifier) {
-            updates.retain(|update| update.generation_boundary != boundary);
-            if updates.is_empty() {
-                self.deferred_forward_tsns.remove(&stream_identifier);
-            }
+            updates.retain(|_| {
+                let retain = !removals[index];
+                index += 1;
+                retain
+            });
+        }
+        if self
+            .deferred_forward_tsns
+            .get(&stream_identifier)
+            .is_some_and(VecDeque::is_empty)
+        {
+            self.deferred_forward_tsns.remove(&stream_identifier);
         }
 
         let became_readable = if let Some(stream) = self.streams.get_mut(&stream_identifier) {
@@ -2755,6 +2786,13 @@ impl Association {
                     self.deferred_reset_data.remove(&chunk.tsn);
                 }
             }
+        }
+
+        // A resolved TSN gap can disambiguate a deferred ordered skip whose
+        // later SSN arrived first on a reset successor.
+        let stream_ids: Vec<StreamId> = self.deferred_forward_tsns.keys().copied().collect();
+        for stream_identifier in stream_ids {
+            self.apply_deferred_forward_tsns(stream_identifier);
         }
 
         let has_packet_loss = !self.payload_queue.is_empty();

--- a/src/association/mod.rs
+++ b/src/association/mod.rs
@@ -31,7 +31,9 @@ use crate::param::param_outgoing_reset_request::ParamOutgoingResetRequest;
 use crate::param::param_reconfig_response::{ParamReconfigResponse, ReconfigResult};
 use crate::param::param_state_cookie::ParamStateCookie;
 use crate::param::param_supported_extensions::ParamSupportedExtensions;
-use crate::queue::{payload_queue::PayloadQueue, pending_queue::PendingQueue};
+use crate::queue::{
+    payload_queue::PayloadQueue, pending_queue::PendingQueue, reassembly_queue::ReassemblyQueue,
+};
 use crate::shared::{AssociationEventInner, AssociationId, EndpointEvent, EndpointEventInner};
 use crate::util::{sna16lt, sna32gt, sna32gte, sna32lt, sna32lte};
 use crate::{AssociationEvent, Payload, Side, Transmit};
@@ -157,7 +159,9 @@ impl PendingResetCompletions {
 
 #[derive(Debug, Copy, Clone)]
 struct DeferredForwardTsn {
-    new_cumulative_tsn: u32,
+    /// The reset boundary ending the generation this update belongs to.
+    /// None identifies the active tail generation after all accepted resets.
+    generation_boundary: Option<u32>,
     last_ssn: u16,
 }
 
@@ -639,7 +643,11 @@ impl Association {
                                 stream_event,
                                 StreamEvent::ResetComplete { .. } | StreamEvent::ResetFailed { .. }
                             ) && self.delivered_stream_finishes.contains(&stream_id);
-                        if !terminal_for_delivered_generation {
+                        let readable_current_generation = matches!(
+                            stream_event,
+                            StreamEvent::Opened { .. } | StreamEvent::Readable { .. }
+                        );
+                        if !terminal_for_delivered_generation && !readable_current_generation {
                             continue;
                         }
                     }
@@ -1254,12 +1262,14 @@ impl Association {
             return;
         }
 
-        let has_unread_data = self
-            .streams
-            .get(&stream_identifier)
-            .is_some_and(|stream| stream.get_num_bytes_in_reassembly_queue() != 0);
+        let has_readable_data = self.streams.get(&stream_identifier).is_some_and(|stream| {
+            matches!(
+                stream.state,
+                RecvSendState::Readable | RecvSendState::ReadWritable
+            ) && stream.get_num_bytes_in_reassembly_queue() != 0
+        });
 
-        if !has_unread_data {
+        if !has_readable_data {
             self.unregister_stream(stream_identifier, true);
             return;
         }
@@ -1776,35 +1786,29 @@ impl Association {
         self.retiring_streams
             .get(&stream_identifier)
             .and_then(|boundaries| boundaries.front().copied())
-            .or_else(|| {
-                self.reconfig_requests
-                    .values()
-                    .find(|request| Self::reset_request_affects_stream(request, stream_identifier))
-                    .map(|request| request.sender_last_tsn)
-            })
     }
 
-    fn forward_tsn_applies_to_current_generation(
-        &self,
-        stream_identifier: StreamId,
-        new_cumulative_tsn: u32,
-    ) -> bool {
-        self.current_reset_boundary(stream_identifier)
-            .is_none_or(|boundary| sna32lte(new_cumulative_tsn, boundary))
+    fn pending_reset_boundary(&self, stream_identifier: StreamId) -> Option<u32> {
+        self.reconfig_requests
+            .values()
+            .find(|request| Self::reset_request_affects_stream(request, stream_identifier))
+            .map(|request| request.sender_last_tsn)
     }
 
-    fn apply_or_defer_ordered_forward_tsn(
-        &mut self,
-        stream_identifier: StreamId,
-        new_cumulative_tsn: u32,
-        last_ssn: u16,
-    ) {
-        if !self.forward_tsn_applies_to_current_generation(stream_identifier, new_cumulative_tsn) {
+    fn forward_tsn_applies_to_current_generation(&self, stream_identifier: StreamId) -> bool {
+        let current_boundary = self.current_reset_boundary(stream_identifier);
+        current_boundary.is_none()
+            || current_boundary == self.pending_reset_boundary(stream_identifier)
+    }
+
+    fn apply_or_defer_ordered_forward_tsn(&mut self, stream_identifier: StreamId, last_ssn: u16) {
+        if !self.forward_tsn_applies_to_current_generation(stream_identifier) {
+            let generation_boundary = self.pending_reset_boundary(stream_identifier);
             self.deferred_forward_tsns
                 .entry(stream_identifier)
                 .or_default()
                 .push_back(DeferredForwardTsn {
-                    new_cumulative_tsn,
+                    generation_boundary,
                     last_ssn,
                 });
             return;
@@ -1821,10 +1825,7 @@ impl Association {
             .keys()
             .copied()
             .filter(|stream_identifier| {
-                self.forward_tsn_applies_to_current_generation(
-                    *stream_identifier,
-                    new_cumulative_tsn,
-                )
+                self.forward_tsn_applies_to_current_generation(*stream_identifier)
             })
             .collect();
         for stream_identifier in stream_ids {
@@ -1845,9 +1846,7 @@ impl Association {
             .get(&stream_identifier)
             .into_iter()
             .flatten()
-            .filter(|update| {
-                boundary.is_none_or(|boundary| sna32lte(update.new_cumulative_tsn, boundary))
-            })
+            .filter(|update| update.generation_boundary == boundary)
             .copied()
             .collect();
 
@@ -1856,9 +1855,7 @@ impl Association {
         }
 
         if let Some(updates) = self.deferred_forward_tsns.get_mut(&stream_identifier) {
-            updates.retain(|update| {
-                boundary.is_some_and(|boundary| sna32gt(update.new_cumulative_tsn, boundary))
-            });
+            updates.retain(|update| update.generation_boundary != boundary);
             if updates.is_empty() {
                 self.deferred_forward_tsns.remove(&stream_identifier);
             }
@@ -1877,7 +1874,7 @@ impl Association {
         boundary: u32,
     ) {
         if let Some(updates) = self.deferred_forward_tsns.get_mut(&stream_identifier) {
-            updates.retain(|update| sna32gt(update.new_cumulative_tsn, boundary));
+            updates.retain(|update| update.generation_boundary != Some(boundary));
             if updates.is_empty() {
                 self.deferred_forward_tsns.remove(&stream_identifier);
             }
@@ -1927,6 +1924,63 @@ impl Association {
             self.deferred_reset_data.remove(&chunk.tsn);
         }
 
+        Ok(())
+    }
+
+    fn deferred_generation_bounds(
+        &self,
+        stream_identifier: StreamId,
+        tsn: u32,
+    ) -> Option<(u32, Option<u32>)> {
+        let retirement_boundaries = self.retiring_streams.get(&stream_identifier);
+        let pending_boundary = self
+            .reconfig_requests
+            .values()
+            .find(|request| Self::reset_request_affects_stream(request, stream_identifier))
+            .map(|request| request.sender_last_tsn);
+
+        let mut boundaries: Vec<u32> = retirement_boundaries
+            .into_iter()
+            .flat_map(|boundaries| boundaries.iter().copied())
+            .collect();
+        if boundaries.is_empty() {
+            boundaries.extend(pending_boundary);
+        }
+
+        let mut lower = *boundaries.first()?;
+        for upper in boundaries.into_iter().skip(1) {
+            if sna32lte(tsn, upper) {
+                return Some((lower, Some(upper)));
+            }
+            lower = upper;
+        }
+        Some((lower, None))
+    }
+
+    fn validate_deferred_reset_data(&self, d: &ChunkPayloadData) -> Result<()> {
+        let Some((lower, upper)) = self.deferred_generation_bounds(d.stream_identifier, d.tsn)
+        else {
+            return Ok(());
+        };
+
+        let mut chunks: Vec<ChunkPayloadData> = self
+            .deferred_reset_data
+            .values()
+            .filter(|chunk| {
+                chunk.stream_identifier == d.stream_identifier
+                    && sna32gt(chunk.tsn, lower)
+                    && upper.is_none_or(|upper| sna32lte(chunk.tsn, upper))
+            })
+            .cloned()
+            .collect();
+        chunks.sort_unstable_by_key(|chunk| chunk.tsn.wrapping_sub(lower));
+
+        let mut validation_queue =
+            ReassemblyQueue::new(d.stream_identifier, self.max_receive_message_size);
+        for chunk in chunks {
+            validation_queue.push(chunk)?;
+        }
+        validation_queue.push(d.clone())?;
         Ok(())
     }
 
@@ -2007,6 +2061,7 @@ impl Association {
         let immediate_sack = d.immediate_sack;
 
         if defer_stream_data {
+            self.validate_deferred_reset_data(d)?;
             if self.payload_queue.push(d.clone(), self.peer_last_tsn) {
                 self.deferred_reset_data.insert(d.tsn, d.clone());
             }
@@ -2229,11 +2284,7 @@ impl Association {
         // corresponding streams so that the abandoned chunks can be removed
         // from the reassemblyQueue.
         for forwarded in &c.streams {
-            self.apply_or_defer_ordered_forward_tsn(
-                forwarded.identifier,
-                c.new_cumulative_tsn,
-                forwarded.sequence,
-            );
+            self.apply_or_defer_ordered_forward_tsn(forwarded.identifier, forwarded.sequence);
         }
 
         // TSN may be forewared for unordered chunks. ForwardTSN chunk does not
@@ -2291,21 +2342,14 @@ impl Association {
         // Handle per-stream entries using the explicit unordered flag
         for forwarded in &c.streams {
             if forwarded.unordered {
-                if self.forward_tsn_applies_to_current_generation(
-                    forwarded.identifier,
-                    c.new_cumulative_tsn,
-                ) {
+                if self.forward_tsn_applies_to_current_generation(forwarded.identifier) {
                     if let Some(s) = self.streams.get_mut(&forwarded.identifier) {
                         s.handle_forward_tsn_for_unordered(c.new_cumulative_tsn);
                     }
                 }
             } else {
                 // MID maps to SSN for ordered streams; truncate to u16
-                self.apply_or_defer_ordered_forward_tsn(
-                    forwarded.identifier,
-                    c.new_cumulative_tsn,
-                    forwarded.mid as u16,
-                );
+                self.apply_or_defer_ordered_forward_tsn(forwarded.identifier, forwarded.mid as u16);
             }
         }
 

--- a/src/association/mod.rs
+++ b/src/association/mod.rs
@@ -159,8 +159,13 @@ impl PendingResetCompletions {
 
 #[derive(Debug, Copy, Clone)]
 enum DeferredForwardTsnKind {
-    Ordered { last_ssn: u16 },
-    Unordered { new_cumulative_tsn: u32 },
+    Ordered {
+        last_ssn: u16,
+        new_cumulative_tsn: u32,
+    },
+    Unordered {
+        new_cumulative_tsn: u32,
+    },
 }
 
 #[derive(Debug, Copy, Clone)]
@@ -1420,6 +1425,9 @@ impl Association {
             stream.reassembly_queue =
                 ReassemblyQueue::new(stream_identifier, self.max_receive_message_size);
         }
+        if !self.stream_reset_blocked(stream_identifier) {
+            self.unregister_stream(stream_identifier, false);
+        }
     }
 
     /// set_state atomically sets the state of the Association.
@@ -1891,17 +1899,61 @@ impl Association {
             || current_boundary == self.pending_reset_boundary(stream_identifier)
     }
 
-    fn apply_or_defer_ordered_forward_tsn(&mut self, stream_identifier: StreamId, last_ssn: u16) {
+    fn apply_or_defer_ordered_forward_tsn(
+        &mut self,
+        stream_identifier: StreamId,
+        last_ssn: u16,
+        new_cumulative_tsn: u32,
+    ) {
         if !self.forward_tsn_applies_to_current_generation(stream_identifier) {
             let generation_boundary = self.pending_reset_boundary(stream_identifier);
-            let kind = DeferredForwardTsnKind::Ordered { last_ssn };
-            self.deferred_forward_tsns
-                .entry(stream_identifier)
-                .or_default()
-                .push_back(DeferredForwardTsn {
-                    generation_boundary,
-                    kind,
+            let kind = {
+                let updates = self
+                    .deferred_forward_tsns
+                    .entry(stream_identifier)
+                    .or_default();
+                let previous = updates.iter_mut().find(|update| {
+                    if update.generation_boundary != generation_boundary {
+                        return false;
+                    }
+                    let DeferredForwardTsnKind::Ordered {
+                        last_ssn: previous_ssn,
+                        ..
+                    } = update.kind
+                    else {
+                        return false;
+                    };
+                    previous_ssn == last_ssn
+                        || (generation_boundary.is_some() && sna16lt(previous_ssn, last_ssn))
                 });
+
+                if let Some(previous) = previous {
+                    let DeferredForwardTsnKind::Ordered {
+                        last_ssn: previous_ssn,
+                        new_cumulative_tsn: previous_cumulative_tsn,
+                    } = &mut previous.kind
+                    else {
+                        unreachable!();
+                    };
+                    if sna16lt(*previous_ssn, last_ssn) {
+                        *previous_ssn = last_ssn;
+                    }
+                    if sna32lt(*previous_cumulative_tsn, new_cumulative_tsn) {
+                        *previous_cumulative_tsn = new_cumulative_tsn;
+                    }
+                    previous.kind
+                } else {
+                    let kind = DeferredForwardTsnKind::Ordered {
+                        last_ssn,
+                        new_cumulative_tsn,
+                    };
+                    updates.push_back(DeferredForwardTsn {
+                        generation_boundary,
+                        kind,
+                    });
+                    kind
+                }
+            };
             self.prune_deferred_reset_data_for_forward_tsn(
                 stream_identifier,
                 generation_boundary,
@@ -2014,8 +2066,13 @@ impl Association {
             let was_readable = stream.reassembly_queue.is_readable();
             for update in ready {
                 match update.kind {
-                    DeferredForwardTsnKind::Ordered { last_ssn } => {
-                        stream.reassembly_queue.forward_tsn_for_ordered(last_ssn);
+                    DeferredForwardTsnKind::Ordered {
+                        last_ssn,
+                        new_cumulative_tsn,
+                    } => {
+                        stream
+                            .reassembly_queue
+                            .forward_tsn_for_ordered_bounded(last_ssn, new_cumulative_tsn);
                     }
                     DeferredForwardTsnKind::Unordered { new_cumulative_tsn } => {
                         stream
@@ -2088,8 +2145,11 @@ impl Association {
             }
         }
         match kind {
-            DeferredForwardTsnKind::Ordered { last_ssn } => {
-                queue.forward_tsn_for_ordered(last_ssn);
+            DeferredForwardTsnKind::Ordered {
+                last_ssn,
+                new_cumulative_tsn,
+            } => {
+                queue.forward_tsn_for_ordered_bounded(last_ssn, new_cumulative_tsn);
             }
             DeferredForwardTsnKind::Unordered { new_cumulative_tsn } => {
                 queue.forward_tsn_for_unordered(new_cumulative_tsn);
@@ -2522,7 +2582,11 @@ impl Association {
         // corresponding streams so that the abandoned chunks can be removed
         // from the reassemblyQueue.
         for forwarded in &c.streams {
-            self.apply_or_defer_ordered_forward_tsn(forwarded.identifier, forwarded.sequence);
+            self.apply_or_defer_ordered_forward_tsn(
+                forwarded.identifier,
+                forwarded.sequence,
+                c.new_cumulative_tsn,
+            );
         }
 
         // TSN may be forwarded for unordered chunks. ForwardTSN chunk does not
@@ -2587,7 +2651,11 @@ impl Association {
                 );
             } else {
                 // MID maps to SSN for ordered streams; truncate to u16
-                self.apply_or_defer_ordered_forward_tsn(forwarded.identifier, forwarded.mid as u16);
+                self.apply_or_defer_ordered_forward_tsn(
+                    forwarded.identifier,
+                    forwarded.mid as u16,
+                    c.new_cumulative_tsn,
+                );
             }
         }
 
@@ -3206,7 +3274,7 @@ impl Association {
         }
 
         // Respond to every request that arrived, fresh, retransmitted
-        // or defered by arrival of in-flight data.
+        // or deferred by arrival of in-flight data.
         //
         // Intermediate re-evaluations that still fail due to in-flight data
         // stay silent rather than repeating "In progress" on every advance.

--- a/src/association/mod.rs
+++ b/src/association/mod.rs
@@ -937,7 +937,7 @@ impl Association {
         for id in ids {
             // An id with a reset still pending must stay armed,
             // so only disarm once nothing is pending.
-            if self.pending_reset_completions.contains(&id)
+            while self.pending_reset_completions.contains(&id)
                 && !self.has_pending_reset_for_stream(id)
             {
                 self.pending_reset_completions.take_one(id);
@@ -1861,6 +1861,21 @@ impl Association {
         reply: &mut Vec<Packet>,
     ) -> Result<()> {
         if let Some(p) = raw.as_any().downcast_ref::<ParamOutgoingResetRequest>() {
+            // RFC 6525 section 5.2.2 E1: the response sequence number in an
+            // Outgoing Reset Request implicitly acknowledges our request.
+            if let Some(c) = self.reconfigs.remove(&p.reconfig_response_sequence_number) {
+                let ids = c
+                    .param_a
+                    .as_ref()
+                    .and_then(|pa| pa.as_any().downcast_ref::<ParamOutgoingResetRequest>())
+                    .map(|pa| pa.stream_identifiers.clone())
+                    .unwrap_or_default();
+                self.emit_reset_complete(ids);
+                if self.reconfigs.is_empty() {
+                    self.timers.stop(Timer::Reconfig);
+                }
+            }
+
             let seq = p.reconfig_request_sequence_number;
             // Detect retransmission of a completed request. An InProgress request
             // is still in reconfig_requests, so we must let those through for
@@ -1916,15 +1931,11 @@ impl Association {
                     ReconfigResult::SuccessNop | ReconfigResult::SuccessPerformed => {
                         self.emit_reset_complete(ids);
                     }
-                    // A denied or failed reset ends the handshake without
-                    // making the id reusable, consume the armed completion
-                    // without notifying.
+                    // A denied or failed reset ends the handshake without making
+                    // the id reusable. Keep its completion armed as a quarantine
+                    // marker until the API can report a terminal failure event.
                     // (InProgress is intercepted early and can never reach this match)
-                    _ => {
-                        for id in ids {
-                            self.pending_reset_completions.take_one(id);
-                        }
-                    }
+                    _ => {}
                 }
             }
             if self.reconfigs.is_empty() {

--- a/src/association/mod.rs
+++ b/src/association/mod.rs
@@ -2036,25 +2036,34 @@ impl Association {
         }
     }
 
-    fn deferred_forward_tsn_is_ready(
+    fn deferred_forward_tsn_application(
         &self,
         stream_identifier: StreamId,
         update: DeferredForwardTsn,
-    ) -> bool {
+    ) -> Option<(DeferredForwardTsnKind, bool)> {
         match update.kind {
             DeferredForwardTsnKind::Ordered {
                 last_ssn,
                 new_cumulative_tsn,
-            } => self.streams.get(&stream_identifier).is_some_and(|stream| {
+            } => self.streams.get(&stream_identifier).and_then(|stream| {
                 stream
                     .reassembly_queue
-                    .can_apply_forward_tsn_for_ordered_bounded(
+                    .applicable_forward_tsn_for_ordered_bounded(
                         last_ssn,
                         new_cumulative_tsn,
                         self.peer_last_tsn,
                     )
+                    .map(|applicable_last_ssn| {
+                        (
+                            DeferredForwardTsnKind::Ordered {
+                                last_ssn: applicable_last_ssn,
+                                new_cumulative_tsn,
+                            },
+                            applicable_last_ssn == last_ssn,
+                        )
+                    })
             }),
-            DeferredForwardTsnKind::Unordered { .. } => true,
+            DeferredForwardTsnKind::Unordered { .. } => Some((update.kind, true)),
         }
     }
 
@@ -2070,11 +2079,15 @@ impl Association {
         let mut removals = Vec::with_capacity(updates.len());
         let mut ready = vec![];
         for update in updates {
-            let remove = update.generation_boundary == boundary
-                && self.deferred_forward_tsn_is_ready(stream_identifier, *update);
+            let application = if update.generation_boundary == boundary {
+                self.deferred_forward_tsn_application(stream_identifier, *update)
+            } else {
+                None
+            };
+            let remove = application.is_some_and(|(_, remove)| remove);
             removals.push(remove);
-            if remove {
-                ready.push(*update);
+            if let Some((kind, _)) = application {
+                ready.push(kind);
             }
         }
 
@@ -2100,8 +2113,8 @@ impl Association {
 
         let became_readable = if let Some(stream) = self.streams.get_mut(&stream_identifier) {
             let was_readable = stream.reassembly_queue.is_readable();
-            for update in ready {
-                match update.kind {
+            for kind in ready {
+                match kind {
                     DeferredForwardTsnKind::Ordered {
                         last_ssn,
                         new_cumulative_tsn,

--- a/src/association/mod.rs
+++ b/src/association/mod.rs
@@ -52,7 +52,7 @@ use core::str::FromStr;
 use core::time::Duration;
 use log::{debug, error, trace, warn};
 use rand::random;
-use rustc_hash::FxHashMap;
+use rustc_hash::{FxHashMap, FxHashSet};
 use std::collections::HashMap;
 use std::time::Instant;
 use thiserror::Error;
@@ -197,11 +197,15 @@ pub struct Association {
     // Reconfig
     my_next_rsn: u32,
     reconfigs: FxHashMap<u32, ChunkReconfig>,
+    /// Locally queued reciprocal requests that have not reached `poll_transmit`.
+    unsent_reconfigs: FxHashSet<u32>,
     reconfig_requests: FxHashMap<u32, ParamOutgoingResetRequest>,
     max_completed_reconfig_rsn: Option<u32>,
     /// Stream ids for which `StreamEvent::Finished` has fired but whose
     /// `StreamEvent::ResetComplete` is still awaited.
     pending_reset_completions: PendingResetCompletions,
+    /// Stream ids for which a successful reset has granted reuse permission.
+    reset_complete_streams: FxHashSet<StreamId>,
 
     // Non-RFC internal data
     remote_addr: SocketAddr,
@@ -289,9 +293,11 @@ impl Default for Association {
             // Reconfig
             my_next_rsn: 0,
             reconfigs: FxHashMap::default(),
+            unsent_reconfigs: FxHashSet::default(),
             reconfig_requests: FxHashMap::default(),
             max_completed_reconfig_rsn: None,
             pending_reset_completions: PendingResetCompletions::default(),
+            reset_complete_streams: FxHashSet::default(),
 
             // Non-RFC internal data
             remote_addr: SocketAddr::from_str("0.0.0.0:0").unwrap(),
@@ -804,6 +810,8 @@ impl Association {
 
             // AssociationLost stops any pending  ResetComplete.
             self.pending_reset_completions.clear();
+            self.reset_complete_streams.clear();
+            self.unsent_reconfigs.clear();
 
             self.events.push_back(Event::AssociationLost {
                 reason: AssociationError::AssociationClosed,
@@ -850,12 +858,14 @@ impl Association {
             return Err(Error::ErrStreamAlreadyExist);
         }
 
-        if self.pending_reset_completions.contains(&stream_identifier)
+        if (self.pending_reset_completions.contains(&stream_identifier)
+            && !self.reset_complete_streams.contains(&stream_identifier))
             || self.has_pending_reset_for_stream(stream_identifier)
         {
             return Err(Error::ErrStreamResetPending);
         }
 
+        self.reset_complete_streams.remove(&stream_identifier);
         if let Some(s) = self.create_stream(stream_identifier, false, default_payload_type) {
             Ok(s)
         } else {
@@ -940,6 +950,7 @@ impl Association {
             // Other generations of the same id may still be pending or quarantined.
             if self.pending_reset_completions.contains(&id) {
                 self.pending_reset_completions.take_one(id);
+                self.reset_complete_streams.insert(id);
                 self.events
                     .push_back(Event::Stream(StreamEvent::ResetComplete { id }));
             }
@@ -964,6 +975,7 @@ impl Association {
             debug!("[{}] unregister_stream {}", self.side, stream_identifier);
             s.state = RecvSendState::Closed;
             if emit_stream_finished {
+                self.reset_complete_streams.remove(&stream_identifier);
                 self.events.push_back(Event::Stream(StreamEvent::Finished {
                     id: stream_identifier,
                 }));
@@ -1862,7 +1874,11 @@ impl Association {
         if let Some(p) = raw.as_any().downcast_ref::<ParamOutgoingResetRequest>() {
             // RFC 6525 section 5.2.2 E1: the response sequence number in an
             // Outgoing Reset Request implicitly acknowledges our request.
-            if self.timers.get(Timer::Reconfig).is_some() {
+            if self.timers.get(Timer::Reconfig).is_some()
+                && !self
+                    .unsent_reconfigs
+                    .contains(&p.reconfig_response_sequence_number)
+            {
                 if let Some(c) = self.reconfigs.remove(&p.reconfig_response_sequence_number) {
                     let ids = c
                         .param_a
@@ -1908,6 +1924,15 @@ impl Association {
             }
             Ok(())
         } else if let Some(p) = raw.as_any().downcast_ref::<ParamReconfigResponse>() {
+            // RFC 6525 section 5.2.1 H1: ignore responses to requests that have
+            // not yet been transmitted (and therefore have no running timer).
+            if self
+                .unsent_reconfigs
+                .contains(&p.reconfig_response_sequence_number)
+            {
+                return Ok(());
+            }
+
             // In progress result means the peer has deferred the request,
             // not answered it. The request stays outstanding and its timer restarts
             // without counting toward the retransmission limit.
@@ -2299,6 +2324,7 @@ impl Association {
             };
 
             self.reconfigs.insert(rsn, c.clone()); // store in the map for retransmission
+            self.unsent_reconfigs.insert(rsn);
 
             let p = self.create_packet(vec![Box::new(c)]);
             reply.push(p);
@@ -2409,6 +2435,9 @@ impl Association {
                     continue;
                 }
             }
+            // Reciprocal RE-CONFIG requests are queued as control packets. Once
+            // the queue is drained by poll_transmit, those RSNs are acknowledgeable.
+            self.unsent_reconfigs.clear();
         }
 
         let state = self.state();
@@ -3262,6 +3291,7 @@ impl Association {
                 // Keep the armed completions as quarantine markers so the ids cannot
                 // be reused without a terminal success event.
                 self.reconfigs.clear();
+                self.unsent_reconfigs.clear();
             }
 
             _ => {}

--- a/src/association/mod.rs
+++ b/src/association/mod.rs
@@ -31,9 +31,9 @@ use crate::param::param_outgoing_reset_request::ParamOutgoingResetRequest;
 use crate::param::param_reconfig_response::{ParamReconfigResponse, ReconfigResult};
 use crate::param::param_state_cookie::ParamStateCookie;
 use crate::param::param_supported_extensions::ParamSupportedExtensions;
-use crate::queue::{
-    payload_queue::PayloadQueue, pending_queue::PendingQueue, reassembly_queue::ReassemblyQueue,
-};
+use crate::queue::payload_queue::PayloadQueue;
+use crate::queue::pending_queue::PendingQueue;
+use crate::queue::reassembly_queue::ReassemblyQueue;
 use crate::shared::{AssociationEventInner, AssociationId, EndpointEvent, EndpointEventInner};
 use crate::util::{sna16lt, sna32gt, sna32gte, sna32lt, sna32lte};
 use crate::{AssociationEvent, Payload, Side, Transmit};
@@ -158,11 +158,17 @@ impl PendingResetCompletions {
 }
 
 #[derive(Debug, Copy, Clone)]
+enum DeferredForwardTsnKind {
+    Ordered { last_ssn: u16 },
+    Unordered { new_cumulative_tsn: u32 },
+}
+
+#[derive(Debug, Copy, Clone)]
 struct DeferredForwardTsn {
     /// The reset boundary ending the generation this update belongs to.
     /// None identifies the active tail generation after all accepted resets.
     generation_boundary: Option<u32>,
-    last_ssn: u16,
+    kind: DeferredForwardTsnKind,
 }
 
 ///Association represents an SCTP association
@@ -1258,6 +1264,13 @@ impl Association {
     fn retire_stream(&mut self, stream_identifier: StreamId, sender_last_tsn: u32) {
         if let Some(boundaries) = self.retiring_streams.get_mut(&stream_identifier) {
             boundaries.push_back(sender_last_tsn);
+            if let Some(updates) = self.deferred_forward_tsns.get_mut(&stream_identifier) {
+                for update in updates {
+                    if update.generation_boundary.is_none() {
+                        update.generation_boundary = Some(sender_last_tsn);
+                    }
+                }
+            }
             self.queue_stream_finished(stream_identifier, false);
             return;
         }
@@ -1286,6 +1299,11 @@ impl Association {
             return Ok(());
         }
 
+        let inherited_state = self
+            .streams
+            .get(&stream_identifier)
+            .map(|stream| stream.state)
+            .unwrap_or(RecvSendState::ReadWritable);
         if let Some(mut stream) = self.streams.remove(&stream_identifier) {
             stream.state = RecvSendState::Closed;
         }
@@ -1305,7 +1323,9 @@ impl Association {
 
             let Some(next_boundary) = next_boundary else {
                 self.retiring_streams.remove(&stream_identifier);
-                return self.release_deferred_reset_data();
+                let result = self.release_deferred_reset_data();
+                self.inherit_stream_state(stream_identifier, inherited_state);
+                return result;
             };
 
             self.release_deferred_generation_data(
@@ -1313,6 +1333,7 @@ impl Association {
                 completed_boundary,
                 next_boundary,
             )?;
+            self.inherit_stream_state(stream_identifier, inherited_state);
 
             let has_unread_data = self
                 .streams
@@ -1329,6 +1350,55 @@ impl Association {
                 stream.state = RecvSendState::Closed;
             }
             self.discard_deferred_forward_tsns_through(stream_identifier, next_boundary);
+        }
+    }
+
+    fn inherit_stream_state(
+        &mut self,
+        stream_identifier: StreamId,
+        inherited_state: RecvSendState,
+    ) {
+        if let Some(stream) = self.streams.get_mut(&stream_identifier) {
+            stream.state = ((stream.state as u8) & (inherited_state as u8)).into();
+        }
+    }
+
+    /// Close every retained incoming generation without replaying its DATA.
+    /// The current StreamState is kept so an application-owned write half and
+    /// its configuration survive a read-side stop.
+    pub(crate) fn discard_retiring_streams(&mut self, stream_identifier: StreamId) {
+        let Some(boundaries) = self.retiring_streams.remove(&stream_identifier) else {
+            return;
+        };
+
+        for _ in boundaries {
+            self.ready_stream_finishes.insert(stream_identifier);
+        }
+        let discarded_tsns: Vec<u32> = self
+            .deferred_reset_data
+            .iter()
+            .filter_map(|(tsn, chunk)| {
+                (chunk.stream_identifier == stream_identifier).then_some(*tsn)
+            })
+            .collect();
+        for tsn in discarded_tsns {
+            self.payload_queue.mark_as_acked(tsn);
+        }
+        self.deferred_reset_data
+            .retain(|_, chunk| chunk.stream_identifier != stream_identifier);
+        self.deferred_forward_tsns.remove(&stream_identifier);
+        self.events.retain(|event| {
+            !matches!(
+                event,
+                Event::Stream(
+                    StreamEvent::Opened { id } | StreamEvent::Readable { id }
+                ) if *id == stream_identifier
+            )
+        });
+
+        if let Some(stream) = self.streams.get_mut(&stream_identifier) {
+            stream.reassembly_queue =
+                ReassemblyQueue::new(stream_identifier, self.max_receive_message_size);
         }
     }
 
@@ -1809,29 +1879,54 @@ impl Association {
                 .or_default()
                 .push_back(DeferredForwardTsn {
                     generation_boundary,
-                    last_ssn,
+                    kind: DeferredForwardTsnKind::Ordered { last_ssn },
+                });
+            return;
+        }
+
+        let became_readable = self
+            .streams
+            .get_mut(&stream_identifier)
+            .is_some_and(|stream| {
+                let was_readable = stream.reassembly_queue.is_readable();
+                stream.reassembly_queue.forward_tsn_for_ordered(last_ssn);
+                !was_readable && stream.reassembly_queue.is_readable()
+            });
+        if became_readable {
+            self.events.push_back(Event::Stream(StreamEvent::Readable {
+                id: stream_identifier,
+            }));
+        }
+    }
+
+    fn apply_or_defer_unordered_forward_tsn(
+        &mut self,
+        stream_identifier: StreamId,
+        new_cumulative_tsn: u32,
+    ) {
+        if !self.forward_tsn_applies_to_current_generation(stream_identifier) {
+            let generation_boundary = self.pending_reset_boundary(stream_identifier);
+            self.deferred_forward_tsns
+                .entry(stream_identifier)
+                .or_default()
+                .push_back(DeferredForwardTsn {
+                    generation_boundary,
+                    kind: DeferredForwardTsnKind::Unordered { new_cumulative_tsn },
                 });
             return;
         }
 
         if let Some(stream) = self.streams.get_mut(&stream_identifier) {
-            stream.handle_forward_tsn_for_ordered(last_ssn);
+            stream
+                .reassembly_queue
+                .forward_tsn_for_unordered(new_cumulative_tsn);
         }
     }
 
     fn apply_unordered_forward_tsn_to_current_streams(&mut self, new_cumulative_tsn: u32) {
-        let stream_ids: Vec<StreamId> = self
-            .streams
-            .keys()
-            .copied()
-            .filter(|stream_identifier| {
-                self.forward_tsn_applies_to_current_generation(*stream_identifier)
-            })
-            .collect();
+        let stream_ids: Vec<StreamId> = self.streams.keys().copied().collect();
         for stream_identifier in stream_ids {
-            if let Some(stream) = self.streams.get_mut(&stream_identifier) {
-                stream.handle_forward_tsn_for_unordered(new_cumulative_tsn);
-            }
+            self.apply_or_defer_unordered_forward_tsn(stream_identifier, new_cumulative_tsn);
         }
     }
 
@@ -1861,10 +1956,28 @@ impl Association {
             }
         }
 
-        if let Some(stream) = self.streams.get_mut(&stream_identifier) {
+        let became_readable = if let Some(stream) = self.streams.get_mut(&stream_identifier) {
+            let was_readable = stream.reassembly_queue.is_readable();
             for update in ready {
-                stream.handle_forward_tsn_for_ordered(update.last_ssn);
+                match update.kind {
+                    DeferredForwardTsnKind::Ordered { last_ssn } => {
+                        stream.reassembly_queue.forward_tsn_for_ordered(last_ssn);
+                    }
+                    DeferredForwardTsnKind::Unordered { new_cumulative_tsn } => {
+                        stream
+                            .reassembly_queue
+                            .forward_tsn_for_unordered(new_cumulative_tsn);
+                    }
+                }
             }
+            !was_readable && stream.reassembly_queue.is_readable()
+        } else {
+            false
+        };
+        if became_readable {
+            self.events.push_back(Event::Stream(StreamEvent::Readable {
+                id: stream_identifier,
+            }));
         }
     }
 
@@ -1886,7 +1999,6 @@ impl Association {
             debug!("[{}] discard {}", self.side, d.stream_sequence_number);
             return Ok(());
         }
-        self.apply_deferred_forward_tsns(d.stream_identifier);
 
         if let Some(stream) = self.streams.get_mut(&d.stream_identifier) {
             let queued = stream.handle_data(d)?;
@@ -1923,6 +2035,7 @@ impl Association {
             self.deliver_deferred_reset_data(&chunk)?;
             self.deferred_reset_data.remove(&chunk.tsn);
         }
+        self.apply_deferred_forward_tsns(stream_identifier);
 
         Ok(())
     }
@@ -1991,10 +2104,15 @@ impl Association {
             .filter(|chunk| !self.data_is_above_pending_reset(chunk))
             .cloned()
             .collect();
+        let stream_ids: FxHashSet<StreamId> =
+            ready.iter().map(|chunk| chunk.stream_identifier).collect();
 
         for chunk in ready {
             self.deliver_deferred_reset_data(&chunk)?;
             self.deferred_reset_data.remove(&chunk.tsn);
+        }
+        for stream_identifier in stream_ids {
+            self.apply_deferred_forward_tsns(stream_identifier);
         }
 
         Ok(())
@@ -2342,11 +2460,10 @@ impl Association {
         // Handle per-stream entries using the explicit unordered flag
         for forwarded in &c.streams {
             if forwarded.unordered {
-                if self.forward_tsn_applies_to_current_generation(forwarded.identifier) {
-                    if let Some(s) = self.streams.get_mut(&forwarded.identifier) {
-                        s.handle_forward_tsn_for_unordered(c.new_cumulative_tsn);
-                    }
-                }
+                self.apply_or_defer_unordered_forward_tsn(
+                    forwarded.identifier,
+                    c.new_cumulative_tsn,
+                );
             } else {
                 // MID maps to SSN for ordered streams; truncate to u16
                 self.apply_or_defer_ordered_forward_tsn(forwarded.identifier, forwarded.mid as u16);
@@ -2910,6 +3027,7 @@ impl Association {
                 p.stream_identifiers.clone()
             };
             stream_ids.sort_unstable();
+            stream_ids.dedup();
 
             for id in stream_ids {
                 if self.streams.contains_key(&id) {

--- a/src/association/mod.rs
+++ b/src/association/mod.rs
@@ -850,7 +850,9 @@ impl Association {
             return Err(Error::ErrStreamAlreadyExist);
         }
 
-        if self.has_pending_reset_for_stream(stream_identifier) {
+        if self.pending_reset_completions.contains(&stream_identifier)
+            || self.has_pending_reset_for_stream(stream_identifier)
+        {
             return Err(Error::ErrStreamResetPending);
         }
 
@@ -930,16 +932,13 @@ impl Association {
         self.set_max_send_message_size(value)
     }
 
-    /// Push [`StreamEvent::ResetComplete`] for each candidate id whose reset
-    /// handshake has completed, `Finished` must have been already fired for it
-    /// and no pending outgoing RE-CONFIG names it.
+    /// Push one [`StreamEvent::ResetComplete`] for each candidate id whose reset
+    /// handshake has completed and `Finished` has already been fired for it.
     fn emit_reset_complete(&mut self, ids: impl IntoIterator<Item = StreamId>) {
         for id in ids {
-            // An id with a reset still pending must stay armed,
-            // so only disarm once nothing is pending.
-            while self.pending_reset_completions.contains(&id)
-                && !self.has_pending_reset_for_stream(id)
-            {
+            // Each acknowledged request completes exactly one stream generation.
+            // Other generations of the same id may still be pending or quarantined.
+            if self.pending_reset_completions.contains(&id) {
                 self.pending_reset_completions.take_one(id);
                 self.events
                     .push_back(Event::Stream(StreamEvent::ResetComplete { id }));
@@ -1863,16 +1862,18 @@ impl Association {
         if let Some(p) = raw.as_any().downcast_ref::<ParamOutgoingResetRequest>() {
             // RFC 6525 section 5.2.2 E1: the response sequence number in an
             // Outgoing Reset Request implicitly acknowledges our request.
-            if let Some(c) = self.reconfigs.remove(&p.reconfig_response_sequence_number) {
-                let ids = c
-                    .param_a
-                    .as_ref()
-                    .and_then(|pa| pa.as_any().downcast_ref::<ParamOutgoingResetRequest>())
-                    .map(|pa| pa.stream_identifiers.clone())
-                    .unwrap_or_default();
-                self.emit_reset_complete(ids);
-                if self.reconfigs.is_empty() {
-                    self.timers.stop(Timer::Reconfig);
+            if self.timers.get(Timer::Reconfig).is_some() {
+                if let Some(c) = self.reconfigs.remove(&p.reconfig_response_sequence_number) {
+                    let ids = c
+                        .param_a
+                        .as_ref()
+                        .and_then(|pa| pa.as_any().downcast_ref::<ParamOutgoingResetRequest>())
+                        .map(|pa| pa.stream_identifiers.clone())
+                        .unwrap_or_default();
+                    self.emit_reset_complete(ids);
+                    if self.reconfigs.is_empty() {
+                        self.timers.stop(Timer::Reconfig);
+                    }
                 }
             }
 
@@ -3257,23 +3258,10 @@ impl Association {
                     self.side,
                     self.reconfigs.len()
                 );
-                // Abandonment ends the handshake without confirmation from the peer,
-                // ids must not be reported as reusable, consume their armed completions
-                // without emitting ResetComplete.
-                let ids: Vec<StreamId> = self
-                    .reconfigs
-                    .values()
-                    .filter_map(|c| {
-                        c.param_a
-                            .as_ref()
-                            .and_then(|pa| pa.as_any().downcast_ref::<ParamOutgoingResetRequest>())
-                    })
-                    .flat_map(|pa| pa.stream_identifiers.iter().copied())
-                    .collect();
+                // Abandonment ends the handshake without confirmation from the peer.
+                // Keep the armed completions as quarantine markers so the ids cannot
+                // be reused without a terminal success event.
                 self.reconfigs.clear();
-                for id in ids {
-                    self.pending_reset_completions.take_one(id);
-                }
             }
 
             _ => {}

--- a/src/association/mod.rs
+++ b/src/association/mod.rs
@@ -205,6 +205,10 @@ pub struct Association {
     /// Application-initiated resets waiting for the active request to finish.
     pending_reset_streams: VecDeque<StreamId>,
     reconfig_requests: FxHashMap<u32, ParamOutgoingResetRequest>,
+    /// DATA received above an InProgress reset boundary. The chunks remain in
+    /// `payload_queue` for TSN accounting but are withheld from stream
+    /// reassembly until the reset creates the next stream generation.
+    deferred_reset_tsns: FxHashSet<u32>,
     max_completed_reconfig_rsn: Option<u32>,
     /// Re-configuration Request Sequence Number most recently accepted from
     /// the peer, initialized to the peer's initial TSN minus one.
@@ -304,6 +308,7 @@ impl Default for Association {
             active_reconfig: None,
             pending_reset_streams: VecDeque::default(),
             reconfig_requests: FxHashMap::default(),
+            deferred_reset_tsns: FxHashSet::default(),
             max_completed_reconfig_rsn: None,
             peer_last_reconfig_rsn: 0,
             pending_reset_completions: PendingResetCompletions::default(),
@@ -824,6 +829,7 @@ impl Association {
             self.pending_reset_streams.clear();
             self.reconfigs.clear();
             self.reconfig_requests.clear();
+            self.deferred_reset_tsns.clear();
             self.control_queue.clear();
             self.active_reconfig = None;
             self.will_retransmit_reconfig = false;
@@ -998,8 +1004,15 @@ impl Association {
                 .iter()
                 .chain(c.param_b.iter())
                 .find_map(|p| p.as_any().downcast_ref::<ParamOutgoingResetRequest>())
-                .is_some_and(|p| p.stream_identifiers.contains(&stream_id))
+                .is_some_and(|p| Self::reset_request_affects_stream(p, stream_id))
         })
+    }
+
+    fn reset_request_affects_stream(
+        request: &ParamOutgoingResetRequest,
+        stream_id: StreamId,
+    ) -> bool {
+        request.stream_identifiers.is_empty() || request.stream_identifiers.contains(&stream_id)
     }
 
     /// Whether the current generation of a stream id is unsafe to send or reuse.
@@ -1064,9 +1077,14 @@ impl Association {
 
     fn reconfig_has_pending_data(&self, rsn: u32) -> bool {
         self.reconfigs.get(&rsn).is_some_and(|c| {
-            Self::reconfig_stream_ids(c)
-                .iter()
-                .any(|id| self.pending_queue.contains_stream(*id))
+            let stream_ids = Self::reconfig_stream_ids(c);
+            if stream_ids.is_empty() {
+                !self.pending_queue.is_empty()
+            } else {
+                stream_ids
+                    .iter()
+                    .any(|id| self.pending_queue.contains_stream(*id))
+            }
         })
     }
 
@@ -1567,6 +1585,49 @@ impl Association {
         Ok(vec![])
     }
 
+    fn data_is_above_pending_reset(&self, d: &ChunkPayloadData) -> bool {
+        self.reconfig_requests.values().any(|request| {
+            Self::reset_request_affects_stream(request, d.stream_identifier)
+                && sna32gt(d.tsn, request.sender_last_tsn)
+        })
+    }
+
+    fn deliver_deferred_reset_data(&mut self, d: &ChunkPayloadData) -> Result<()> {
+        if self.get_or_create_stream(d.stream_identifier).is_none() {
+            debug!("[{}] discard {}", self.side, d.stream_sequence_number);
+            return Ok(());
+        }
+
+        if let Some(stream) = self.streams.get_mut(&d.stream_identifier) {
+            let queued = stream.handle_data(d)?;
+            self.events.push_back(Event::DatagramReceived);
+            if queued && stream.reassembly_queue.is_readable() {
+                self.events.push_back(Event::Stream(StreamEvent::Readable {
+                    id: d.stream_identifier,
+                }));
+            }
+        }
+
+        Ok(())
+    }
+
+    fn release_deferred_reset_data(&mut self) -> Result<()> {
+        let ready: Vec<ChunkPayloadData> = self
+            .deferred_reset_tsns
+            .iter()
+            .filter_map(|tsn| self.payload_queue.get(*tsn))
+            .filter(|chunk| !self.data_is_above_pending_reset(chunk))
+            .cloned()
+            .collect();
+
+        for chunk in ready {
+            self.deliver_deferred_reset_data(&chunk)?;
+            self.deferred_reset_tsns.remove(&chunk.tsn);
+        }
+
+        Ok(())
+    }
+
     fn handle_data(&mut self, d: &ChunkPayloadData) -> Result<Vec<Packet>> {
         trace!(
             "[{}] DATA: tsn={} immediateSack={} len={}",
@@ -1579,7 +1640,21 @@ impl Association {
 
         let can_push = self.payload_queue.can_push(d, self.peer_last_tsn);
         let mut stream_handle_data = false;
-        if can_push {
+        let mut defer_stream_data = false;
+        if can_push && self.data_is_above_pending_reset(d) {
+            if self.get_my_receiver_window_credit() > 0 {
+                defer_stream_data = true;
+            } else if let Some(last_tsn) = self.payload_queue.get_last_tsn_received() {
+                if sna32lt(d.tsn, *last_tsn) {
+                    debug!(
+                        "[{}] receive buffer full, but accepted deferred \
+                        reset DATA as missing chunk tsn={} ssn={}",
+                        self.side, d.tsn, d.stream_sequence_number
+                    );
+                    defer_stream_data = true;
+                }
+            }
+        } else if can_push {
             if self.get_or_create_stream(d.stream_identifier).is_some() {
                 if self.get_my_receiver_window_credit() > 0 {
                     // Pass the new chunk to stream level as soon as it arrives
@@ -1612,7 +1687,11 @@ impl Association {
 
         let immediate_sack = d.immediate_sack;
 
-        if stream_handle_data {
+        if defer_stream_data {
+            if self.payload_queue.push(d.clone(), self.peer_last_tsn) {
+                self.deferred_reset_tsns.insert(d.tsn);
+            }
+        } else if stream_handle_data {
             if let Some(s) = self.streams.get_mut(&d.stream_identifier) {
                 let queued = s.handle_data(d)?;
                 // Only commit to payload_queue after reassembly accepts the chunk
@@ -1820,8 +1899,11 @@ impl Association {
 
         // Advance peer_last_tsn
         while sna32lt(self.peer_last_tsn, c.new_cumulative_tsn) {
-            self.payload_queue.pop(self.peer_last_tsn + 1); // may not exist
-            self.peer_last_tsn += 1;
+            let next_tsn = self.peer_last_tsn.wrapping_add(1);
+            if let Some(chunk) = self.payload_queue.pop(next_tsn) {
+                self.deferred_reset_tsns.remove(&chunk.tsn);
+            }
+            self.peer_last_tsn = next_tsn;
         }
 
         // Report new peer_last_tsn value and abandoned largest SSN value to
@@ -1842,7 +1924,10 @@ impl Association {
             s.handle_forward_tsn_for_unordered(c.new_cumulative_tsn);
         }
 
-        self.handle_peer_last_tsn_and_acknowledgement(false)
+        let mut reply = vec![];
+        self.reevaluate_pending_reset_requests(&mut reply)?;
+        reply.extend(self.handle_peer_last_tsn_and_acknowledgement(false)?);
+        Ok(reply)
     }
 
     /// Handle I-FORWARD-TSN (RFC 8260) — identical to FORWARD-TSN but with
@@ -1877,8 +1962,11 @@ impl Association {
 
         // Advance peer_last_tsn
         while sna32lt(self.peer_last_tsn, c.new_cumulative_tsn) {
-            self.payload_queue.pop(self.peer_last_tsn + 1);
-            self.peer_last_tsn += 1;
+            let next_tsn = self.peer_last_tsn.wrapping_add(1);
+            if let Some(chunk) = self.payload_queue.pop(next_tsn) {
+                self.deferred_reset_tsns.remove(&chunk.tsn);
+            }
+            self.peer_last_tsn = next_tsn;
         }
 
         // Handle per-stream entries using the explicit unordered flag
@@ -1900,7 +1988,10 @@ impl Association {
             s.handle_forward_tsn_for_unordered(c.new_cumulative_tsn);
         }
 
-        self.handle_peer_last_tsn_and_acknowledgement(false)
+        let mut reply = vec![];
+        self.reevaluate_pending_reset_requests(&mut reply)?;
+        reply.extend(self.handle_peer_last_tsn_and_acknowledgement(false)?);
+        Ok(reply)
     }
 
     fn handle_shutdown(&mut self, _: &ChunkShutdown) -> Result<Vec<Packet>> {
@@ -1950,6 +2041,19 @@ impl Association {
         Ok(vec![])
     }
 
+    fn reevaluate_pending_reset_requests(&mut self, reply: &mut Vec<Packet>) -> Result<()> {
+        let requests: Vec<ParamOutgoingResetRequest> =
+            self.reconfig_requests.values().cloned().collect();
+        for request in requests {
+            let seq = request.reconfig_request_sequence_number;
+            self.reset_streams_if_any(&request, false, reply)?;
+            if !self.reconfig_requests.contains_key(&seq) {
+                self.max_completed_reconfig_rsn = Some(seq);
+            }
+        }
+        Ok(())
+    }
+
     /// A common routine for handle_data and handle_forward_tsn routines
     fn handle_peer_last_tsn_and_acknowledgement(
         &mut self,
@@ -1965,18 +2069,14 @@ impl Association {
         // Meaning, if peer_last_tsn+1 points to a chunk that is received,
         // advance peer_last_tsn until peer_last_tsn+1 points to unreceived chunk.
         //debug!("[{}] peer_last_tsn = {}", self.side, self.peer_last_tsn);
-        while self.payload_queue.pop(self.peer_last_tsn + 1).is_some() {
-            self.peer_last_tsn += 1;
+        while let Some(chunk) = self.payload_queue.pop(self.peer_last_tsn.wrapping_add(1)) {
+            self.peer_last_tsn = self.peer_last_tsn.wrapping_add(1);
             //debug!("[{}] peer_last_tsn = {}", self.side, self.peer_last_tsn);
 
-            let rst_reqs: Vec<ParamOutgoingResetRequest> =
-                self.reconfig_requests.values().cloned().collect();
-            for rst_req in rst_reqs {
-                let seq = rst_req.reconfig_request_sequence_number;
-                self.reset_streams_if_any(&rst_req, false, &mut reply)?;
-                if !self.reconfig_requests.contains_key(&seq) {
-                    self.max_completed_reconfig_rsn = Some(seq);
-                }
+            self.reevaluate_pending_reset_requests(&mut reply)?;
+
+            if self.deferred_reset_tsns.remove(&chunk.tsn) {
+                self.deliver_deferred_reset_data(&chunk)?;
             }
         }
 
@@ -2397,10 +2497,17 @@ impl Association {
                 "[{}] resetStream(): senderLastTSN={} <= peer_last_tsn={}",
                 self.side, p.sender_last_tsn, self.peer_last_tsn
             );
-            for id in &p.stream_identifiers {
-                if self.streams.contains_key(id) {
-                    sis_to_reset.push(*id);
-                    self.unregister_stream(*id, true);
+            let mut stream_ids = if p.stream_identifiers.is_empty() {
+                self.streams.keys().copied().collect::<Vec<_>>()
+            } else {
+                p.stream_identifiers.clone()
+            };
+            stream_ids.sort_unstable();
+
+            for id in stream_ids {
+                if self.streams.contains_key(&id) {
+                    sis_to_reset.push(id);
+                    self.unregister_stream(id, true);
                 }
             }
             self.reconfig_requests
@@ -2440,6 +2547,10 @@ impl Association {
 
             let p = self.create_packet(vec![Box::new(c)]);
             reply.push(p);
+        }
+
+        if performed {
+            self.release_deferred_reset_data()?;
         }
 
         // Respond to every request that arrived, fresh, retransmitted
@@ -2529,6 +2640,11 @@ impl Association {
         for s in self.streams.values() {
             bytes_queued += s.get_num_bytes_in_reassembly_queue() as u32;
         }
+        for tsn in &self.deferred_reset_tsns {
+            if let Some(chunk) = self.payload_queue.get(*tsn) {
+                bytes_queued += chunk.user_data.len() as u32;
+            }
+        }
 
         self.max_receive_buffer_size.saturating_sub(bytes_queued)
     }
@@ -2574,13 +2690,20 @@ impl Association {
     ) -> Vec<Bytes> {
         if !self.control_queue.is_empty() {
             let mut buffered = VecDeque::new();
+            let mut request_blocked = false;
             let queued = core::mem::take(&mut self.control_queue);
             for p in queued {
                 let outgoing_rsn = Self::packet_reconfig_request_rsn(&p);
 
+                if outgoing_rsn.is_some() && request_blocked {
+                    buffered.push_back(p);
+                    continue;
+                }
+
                 if outgoing_rsn.is_some_and(|rsn| {
                     self.active_reconfig.is_some() && self.active_reconfig != Some(rsn)
                 }) {
+                    request_blocked = true;
                     buffered.push_back(p);
                     continue;
                 }
@@ -2588,6 +2711,7 @@ impl Association {
                 // The reset boundary cannot be fixed until all already-queued
                 // DATA for the affected streams has received a TSN.
                 if outgoing_rsn.is_some_and(|rsn| self.reconfig_has_pending_data(rsn)) {
+                    request_blocked = true;
                     buffered.push_back(p);
                     continue;
                 }
@@ -2609,6 +2733,7 @@ impl Association {
                         warn!("[{}] failed to serialize a control packet", self.side);
                         // A queued request owns reset state and must not be lost.
                         if outgoing_rsn.is_some() {
+                            request_blocked = true;
                             buffered.push_back(p);
                         }
                     }

--- a/src/association/mod.rs
+++ b/src/association/mod.rs
@@ -35,7 +35,7 @@ use crate::queue::{payload_queue::PayloadQueue, pending_queue::PendingQueue};
 use crate::shared::{AssociationEventInner, AssociationId, EndpointEvent, EndpointEventInner};
 use crate::util::{sna16lt, sna32gt, sna32gte, sna32lt, sna32lte};
 use crate::{AssociationEvent, Payload, Side, Transmit};
-use stream::{ReliabilityType, Stream, StreamEvent, StreamId, StreamState};
+use stream::{ReliabilityType, Stream, StreamEvent, StreamId, StreamResetError, StreamState};
 use timer::{ACK_INTERVAL, RtoManager, Timer, TimerTable};
 
 use crate::association::stream::RecvSendState;
@@ -121,8 +121,8 @@ pub enum Event {
     DatagramReceived,
 }
 
-/// Multiset of stream ids owing a [`StreamEvent::ResetComplete`].
-/// Each `Finished` for an id arms one completion, a re-created id is a distinct
+/// Multiset of stream ids owing a terminal reset event.
+/// Each `Finished` for an id arms one result, a re-created id is a distinct
 /// generation and owes its own.
 #[derive(Debug, Default)]
 struct PendingResetCompletions(FxHashMap<StreamId, usize>);
@@ -138,12 +138,15 @@ impl PendingResetCompletions {
     }
 
     /// Consume one armed completion for this id.
-    fn take_one(&mut self, id: StreamId) {
+    fn take_one(&mut self, id: StreamId) -> bool {
         if let Some(count) = self.0.get_mut(&id) {
             *count -= 1;
             if *count == 0 {
                 self.0.remove(&id);
             }
+            true
+        } else {
+            false
         }
     }
 
@@ -197,15 +200,17 @@ pub struct Association {
     // Reconfig
     my_next_rsn: u32,
     reconfigs: FxHashMap<u32, ChunkReconfig>,
-    /// Locally queued reciprocal requests that have not reached `poll_transmit`.
-    unsent_reconfigs: FxHashSet<u32>,
+    /// The one request whose Re-configuration Timer is running.
+    active_reconfig: Option<u32>,
+    /// Application-initiated resets waiting for the active request to finish.
+    pending_reset_streams: VecDeque<StreamId>,
     reconfig_requests: FxHashMap<u32, ParamOutgoingResetRequest>,
     max_completed_reconfig_rsn: Option<u32>,
-    /// Stream ids for which `StreamEvent::Finished` has fired but whose
-    /// `StreamEvent::ResetComplete` is still awaited.
+    /// Stream ids for which `StreamEvent::Finished` has fired but whose terminal
+    /// reset event is still awaited.
     pending_reset_completions: PendingResetCompletions,
-    /// Stream ids for which a successful reset has granted reuse permission.
-    reset_complete_streams: FxHashSet<StreamId>,
+    /// Stream ids whose latest completed reset was unsuccessful.
+    failed_reset_streams: FxHashSet<StreamId>,
 
     // Non-RFC internal data
     remote_addr: SocketAddr,
@@ -293,11 +298,12 @@ impl Default for Association {
             // Reconfig
             my_next_rsn: 0,
             reconfigs: FxHashMap::default(),
-            unsent_reconfigs: FxHashSet::default(),
+            active_reconfig: None,
+            pending_reset_streams: VecDeque::default(),
             reconfig_requests: FxHashMap::default(),
             max_completed_reconfig_rsn: None,
             pending_reset_completions: PendingResetCompletions::default(),
-            reset_complete_streams: FxHashSet::default(),
+            failed_reset_streams: FxHashSet::default(),
 
             // Non-RFC internal data
             remote_addr: SocketAddr::from_str("0.0.0.0:0").unwrap(),
@@ -565,10 +571,6 @@ impl Association {
     #[must_use]
     pub fn poll(&mut self) -> Option<Event> {
         if let Some(x) = self.events.pop_front() {
-            if let Event::Stream(StreamEvent::ResetComplete { id }) = x {
-                self.reset_complete_streams.insert(id);
-                return Some(Event::Stream(StreamEvent::ResetComplete { id }));
-            }
             return Some(x);
         }
 
@@ -814,8 +816,9 @@ impl Association {
 
             // AssociationLost stops any pending  ResetComplete.
             self.pending_reset_completions.clear();
-            self.reset_complete_streams.clear();
-            self.unsent_reconfigs.clear();
+            self.failed_reset_streams.clear();
+            self.pending_reset_streams.clear();
+            self.active_reconfig = None;
 
             self.events.push_back(Event::AssociationLost {
                 reason: AssociationError::AssociationClosed,
@@ -862,14 +865,10 @@ impl Association {
             return Err(Error::ErrStreamAlreadyExist);
         }
 
-        if (self.pending_reset_completions.contains(&stream_identifier)
-            && !self.reset_complete_streams.contains(&stream_identifier))
-            || self.has_pending_reset_for_stream(stream_identifier)
-        {
+        if self.stream_reset_blocked(stream_identifier) {
             return Err(Error::ErrStreamResetPending);
         }
 
-        self.reset_complete_streams.remove(&stream_identifier);
         if let Some(s) = self.create_stream(stream_identifier, false, default_payload_type) {
             Ok(s)
         } else {
@@ -950,18 +949,35 @@ impl Association {
     /// handshake has completed and `Finished` has already been fired for it.
     fn emit_reset_complete(&mut self, ids: impl IntoIterator<Item = StreamId>) {
         for id in ids {
-            // Each acknowledged request completes exactly one stream generation.
-            // Other generations of the same id may still be pending or quarantined.
-            if self.pending_reset_completions.contains(&id) {
-                self.pending_reset_completions.take_one(id);
+            let notify = self.pending_reset_completions.take_one(id);
+            // Requests are serialized, so a success supersedes any older failure
+            // for the same stream id. A newer pending generation still blocks reuse.
+            self.failed_reset_streams.remove(&id);
+            if !self.stream_reset_blocked(id) {
                 if let Some(stream) = self.streams.get_mut(&id) {
                     if stream.state == RecvSendState::Readable {
                         stream.state = RecvSendState::ReadWritable;
                     }
                 }
+            }
+            if notify {
                 self.events
                     .push_back(Event::Stream(StreamEvent::ResetComplete { id }));
             }
+        }
+    }
+
+    /// Report a terminal reset failure and keep the stream id quarantined.
+    fn emit_reset_failed(
+        &mut self,
+        ids: impl IntoIterator<Item = StreamId>,
+        reason: StreamResetError,
+    ) {
+        for id in ids {
+            self.pending_reset_completions.take_one(id);
+            self.failed_reset_streams.insert(id);
+            self.events
+                .push_back(Event::Stream(StreamEvent::ResetFailed { id, reason }));
         }
     }
 
@@ -970,10 +986,78 @@ impl Association {
     fn has_pending_reset_for_stream(&self, stream_id: StreamId) -> bool {
         self.reconfigs.values().any(|c| {
             c.param_a
-                .as_ref()
-                .and_then(|p| p.as_any().downcast_ref::<ParamOutgoingResetRequest>())
+                .iter()
+                .chain(c.param_b.iter())
+                .find_map(|p| p.as_any().downcast_ref::<ParamOutgoingResetRequest>())
                 .is_some_and(|p| p.stream_identifiers.contains(&stream_id))
         })
+    }
+
+    /// Whether the current generation of a stream id is unsafe to send or reuse.
+    fn stream_reset_blocked(&self, stream_id: StreamId) -> bool {
+        self.pending_reset_completions.contains(&stream_id)
+            || self.failed_reset_streams.contains(&stream_id)
+            || self.stream_reset_in_progress(stream_id)
+    }
+
+    /// Whether a request currently prevents assigning new SSNs for this stream.
+    fn stream_reset_in_progress(&self, stream_id: StreamId) -> bool {
+        self.pending_reset_streams.contains(&stream_id)
+            || self.has_pending_reset_for_stream(stream_id)
+    }
+
+    fn reconfig_stream_ids(c: &ChunkReconfig) -> Vec<StreamId> {
+        c.param_a
+            .iter()
+            .chain(c.param_b.iter())
+            .find_map(|p| p.as_any().downcast_ref::<ParamOutgoingResetRequest>())
+            .map(|p| p.stream_identifiers.clone())
+            .unwrap_or_default()
+    }
+
+    fn packet_reconfig_request_rsn(packet: &Packet) -> Option<u32> {
+        packet.chunks.iter().find_map(|chunk| {
+            let reconfig = chunk.as_any().downcast_ref::<ChunkReconfig>()?;
+            reconfig
+                .param_a
+                .iter()
+                .chain(reconfig.param_b.iter())
+                .find_map(|param| {
+                    param
+                        .as_any()
+                        .downcast_ref::<ParamOutgoingResetRequest>()
+                        .map(|request| request.reconfig_request_sequence_number)
+                })
+        })
+    }
+
+    /// Finish the one request associated with the running Re-configuration Timer.
+    fn finish_reconfig(
+        &mut self,
+        rsn: u32,
+        outcome: core::result::Result<(), StreamResetError>,
+    ) -> bool {
+        if self.active_reconfig != Some(rsn) {
+            return false;
+        }
+
+        let ids = self
+            .reconfigs
+            .remove(&rsn)
+            .map(|c| Self::reconfig_stream_ids(&c))
+            .unwrap_or_default();
+        self.active_reconfig = None;
+        self.will_retransmit_reconfig = false;
+        self.timers.stop(Timer::Reconfig);
+
+        match outcome {
+            Ok(()) => self.emit_reset_complete(ids),
+            Err(reason) => self.emit_reset_failed(ids, reason),
+        }
+
+        // A buffered request or locally queued reset can now become active.
+        self.awake_write_loop();
+        true
     }
 
     /// unregister_stream un-registers a stream from the association
@@ -983,12 +1067,11 @@ impl Association {
             debug!("[{}] unregister_stream {}", self.side, stream_identifier);
             s.state = RecvSendState::Closed;
             if emit_stream_finished {
-                self.reset_complete_streams.remove(&stream_identifier);
                 self.events.push_back(Event::Stream(StreamEvent::Finished {
                     id: stream_identifier,
                 }));
-                // Every Finished owes a ResetComplete once the handshake
-                // complete, even if the peer re-creates the stream id first.
+                // Every Finished owes a terminal reset event, even if the peer
+                // re-creates the stream id before the handshake completes.
                 self.pending_reset_completions.insert(stream_identifier);
             }
         }
@@ -1882,29 +1965,7 @@ impl Association {
         if let Some(p) = raw.as_any().downcast_ref::<ParamOutgoingResetRequest>() {
             // RFC 6525 section 5.2.2 E1: the response sequence number in an
             // Outgoing Reset Request implicitly acknowledges our request.
-            if self.timers.get(Timer::Reconfig).is_some()
-                && !self
-                    .unsent_reconfigs
-                    .contains(&p.reconfig_response_sequence_number)
-            {
-                if let Some(c) = self.reconfigs.remove(&p.reconfig_response_sequence_number) {
-                    let ids = c
-                        .param_a
-                        .as_ref()
-                        .and_then(|pa| pa.as_any().downcast_ref::<ParamOutgoingResetRequest>())
-                        .map(|pa| pa.stream_identifiers.clone())
-                        .unwrap_or_default();
-                    self.emit_reset_complete(ids);
-                    if self
-                        .reconfigs
-                        .keys()
-                        .all(|rsn| self.unsent_reconfigs.contains(rsn))
-                    {
-                        self.timers.stop(Timer::Reconfig);
-                        self.awake_write_loop();
-                    }
-                }
-            }
+            self.finish_reconfig(p.reconfig_response_sequence_number, Ok(()));
 
             let seq = p.reconfig_request_sequence_number;
             // Detect retransmission of a completed request. An InProgress request
@@ -1937,12 +1998,10 @@ impl Association {
             }
             Ok(())
         } else if let Some(p) = raw.as_any().downcast_ref::<ParamReconfigResponse>() {
-            // RFC 6525 section 5.2.1 H1: ignore responses to requests that have
-            // not yet been transmitted (and therefore have no running timer).
-            if self
-                .unsent_reconfigs
-                .contains(&p.reconfig_response_sequence_number)
-            {
+            let rsn = p.reconfig_response_sequence_number;
+            // RFC 6525 section 5.2.7 H1: ignore responses unless this RSN owns
+            // the running Re-configuration Timer.
+            if self.active_reconfig != Some(rsn) {
                 return Ok(());
             }
 
@@ -1950,41 +2009,22 @@ impl Association {
             // not answered it. The request stays outstanding and its timer restarts
             // without counting toward the retransmission limit.
             if p.result == ReconfigResult::InProgress {
-                if self
-                    .reconfigs
-                    .contains_key(&p.reconfig_response_sequence_number)
-                {
-                    self.timers.stop(Timer::Reconfig);
+                if self.reconfigs.contains_key(&rsn) {
+                    // Pause without resetting the existing retry count. The outbound
+                    // poll starts it again and the next expiry is exempted by H2.
+                    self.timers.set(Timer::Reconfig, None);
                     self.timers.suppress_error_count(Timer::Reconfig);
+                    self.awake_write_loop();
                 }
                 return Ok(());
             }
-            if let Some(c) = self.reconfigs.remove(&p.reconfig_response_sequence_number) {
-                let ids: Vec<StreamId> = c
-                    .param_a
-                    .as_ref()
-                    .and_then(|pa| pa.as_any().downcast_ref::<ParamOutgoingResetRequest>())
-                    .map(|pa| pa.stream_identifiers.clone())
-                    .unwrap_or_default();
-                match p.result {
-                    ReconfigResult::SuccessNop | ReconfigResult::SuccessPerformed => {
-                        self.emit_reset_complete(ids);
-                    }
-                    // A denied or failed reset ends the handshake without making
-                    // the id reusable. Keep its completion armed as a quarantine
-                    // marker until the API can report a terminal failure event.
-                    // (InProgress is intercepted early and can never reach this match)
-                    _ => {}
-                }
-            }
-            if self
-                .reconfigs
-                .keys()
-                .all(|rsn| self.unsent_reconfigs.contains(rsn))
-            {
-                self.timers.stop(Timer::Reconfig);
-                self.awake_write_loop();
-            }
+
+            let outcome = match p.result {
+                ReconfigResult::SuccessNop | ReconfigResult::SuccessPerformed => Ok(()),
+                ReconfigResult::Denied => Err(StreamResetError::Denied),
+                _ => Err(StreamResetError::Failed),
+            };
+            self.finish_reconfig(rsn, outcome);
             Ok(())
         } else {
             Err(Error::ErrParameterType)
@@ -2341,8 +2381,9 @@ impl Association {
                 ..Default::default()
             };
 
-            self.reconfigs.insert(rsn, c.clone()); // store in the map for retransmission
-            self.unsent_reconfigs.insert(rsn);
+            // Store before queueing. It becomes the active retransmission entry only
+            // when gather_outbound actually serializes this packet.
+            self.reconfigs.insert(rsn, c.clone());
 
             let p = self.create_packet(vec![Box::new(c)]);
             reply.push(p);
@@ -2399,10 +2440,7 @@ impl Association {
             default_payload_type,
         );
 
-        if accept
-            && (self.pending_reset_completions.contains(&stream_identifier)
-                || self.has_pending_reset_for_stream(stream_identifier))
-        {
+        if accept && self.stream_reset_blocked(stream_identifier) {
             s.state = RecvSendState::Readable;
         }
 
@@ -2453,35 +2491,31 @@ impl Association {
 
         if !self.control_queue.is_empty() {
             let mut buffered = VecDeque::new();
-            let timer_running = self.timers.get(Timer::Reconfig).is_some();
             let queued = core::mem::take(&mut self.control_queue);
             for p in queued {
-                let outgoing_rsn = p.chunks.iter().find_map(|chunk| {
-                    chunk
-                        .as_any()
-                        .downcast_ref::<ChunkReconfig>()
-                        .and_then(|reconfig| reconfig.param_a.as_ref())
-                        .and_then(|param| {
-                            param.as_any().downcast_ref::<ParamOutgoingResetRequest>()
-                        })
-                        .map(|request| request.reconfig_request_sequence_number)
-                });
+                let outgoing_rsn = Self::packet_reconfig_request_rsn(&p);
 
-                if timer_running
-                    && outgoing_rsn.is_some_and(|rsn| self.unsent_reconfigs.contains(&rsn))
-                {
+                if outgoing_rsn.is_some_and(|rsn| {
+                    self.active_reconfig.is_some() && self.active_reconfig != Some(rsn)
+                }) {
                     buffered.push_back(p);
                     continue;
                 }
 
-                if let Ok(raw) = p.marshal() {
-                    raw_packets.push(raw);
-                    if let Some(rsn) = outgoing_rsn {
-                        self.unsent_reconfigs.remove(&rsn);
+                match p.marshal() {
+                    Ok(raw) => {
+                        raw_packets.push(raw);
+                        if let Some(rsn) = outgoing_rsn {
+                            self.active_reconfig = Some(rsn);
+                        }
                     }
-                } else {
-                    warn!("[{}] failed to serialize a control packet", self.side);
-                    continue;
+                    Err(_) => {
+                        warn!("[{}] failed to serialize a control packet", self.side);
+                        // A queued request owns reset state and must not be lost.
+                        if outgoing_rsn.is_some() {
+                            buffered.push_back(p);
+                        }
+                    }
                 }
             }
             self.control_queue = buffered;
@@ -2538,7 +2572,7 @@ impl Association {
     ) -> Vec<Bytes> {
         // Pop unsent data chunks from the pending queue to send as much as
         // cwnd and rwnd allow.
-        let (chunks, sis_to_reset) = self.pop_pending_data_chunks_to_send(now);
+        let chunks = self.pop_pending_data_chunks_to_send(now);
         if !chunks.is_empty() {
             // Start timer. (noop if already started)
             trace!("[{}] T3-rtx timer start (pt1)", self.side);
@@ -2554,15 +2588,11 @@ impl Association {
             }
         }
 
-        if !sis_to_reset.is_empty() || self.will_retransmit_reconfig {
-            if self.will_retransmit_reconfig {
-                self.will_retransmit_reconfig = false;
-                debug!(
-                    "[{}] retransmit {} RECONFIG chunk(s)",
-                    self.side,
-                    self.reconfigs.len()
-                );
-                for c in self.reconfigs.values() {
+        if self.will_retransmit_reconfig {
+            self.will_retransmit_reconfig = false;
+            if let Some(rsn) = self.active_reconfig {
+                debug!("[{}] retransmit RECONFIG rsn={}", self.side, rsn);
+                if let Some(c) = self.reconfigs.get(&rsn) {
                     let p = self.create_packet(vec![Box::new(c.clone())]);
                     if let Ok(raw) = p.marshal() {
                         raw_packets.push(raw);
@@ -2574,55 +2604,50 @@ impl Association {
                     }
                 }
             }
+        }
 
-            if !sis_to_reset.is_empty() {
-                let rsn = self.generate_next_rsn();
-                let tsn = self.my_next_tsn - 1;
-                debug!(
-                    "[{}] sending RECONFIG: rsn={} tsn={} streams={:?}",
-                    self.side,
-                    rsn,
-                    self.my_next_tsn - 1,
-                    sis_to_reset
-                );
+        // RFC 6525 section 5.1.1 permits only one request in flight. Keep
+        // application resets separate from DATA until that request completes.
+        if self.active_reconfig.is_none()
+            && self.pending_queue.is_empty()
+            && !self.pending_reset_streams.is_empty()
+        {
+            let stream_ids: Vec<_> = self.pending_reset_streams.drain(..).collect();
+            let rsn = self.generate_next_rsn();
+            let tsn = self.my_next_tsn - 1;
+            debug!(
+                "[{}] sending RECONFIG: rsn={} tsn={} streams={:?}",
+                self.side, rsn, tsn, stream_ids
+            );
 
-                let c = ChunkReconfig {
-                    param_a: Some(Box::new(ParamOutgoingResetRequest {
-                        reconfig_request_sequence_number: rsn,
-                        sender_last_tsn: tsn,
-                        stream_identifiers: sis_to_reset,
-                        ..Default::default()
-                    })),
+            let c = ChunkReconfig {
+                param_a: Some(Box::new(ParamOutgoingResetRequest {
+                    reconfig_request_sequence_number: rsn,
+                    sender_last_tsn: tsn,
+                    stream_identifiers: stream_ids,
                     ..Default::default()
-                };
-                self.reconfigs.insert(rsn, c.clone()); // store in the map for retransmission
+                })),
+                ..Default::default()
+            };
+            self.reconfigs.insert(rsn, c.clone());
 
-                let p = self.create_packet(vec![Box::new(c)]);
-                if let Ok(raw) = p.marshal() {
-                    raw_packets.push(raw);
-                } else {
-                    warn!(
-                        "[{}] failed to serialize a RECONFIG packet to be transmitted",
-                        self.side
-                    );
-                }
-            }
-
-            if !self.reconfigs.is_empty() {
-                self.timers
-                    .start(Timer::Reconfig, now, self.rto_mgr.get_rto());
+            let p = self.create_packet(vec![Box::new(c)]);
+            if let Ok(raw) = p.marshal() {
+                self.active_reconfig = Some(rsn);
+                raw_packets.push(raw);
+            } else {
+                warn!(
+                    "[{}] failed to serialize a RECONFIG packet to be transmitted",
+                    self.side
+                );
+                // Preserve the request for a later serialization attempt.
+                self.control_queue.push_back(p);
             }
         }
 
-        // Ensure the Reconfig timer is running whenever reconfigs are pending.
-        // Reconfigs can be inserted via reset_streams_if_any (incoming reset
-        // response path) without going through the sis_to_reset / retransmit
-        // block above.
-        if self
-            .reconfigs
-            .keys()
-            .any(|rsn| !self.unsent_reconfigs.contains(rsn))
-        {
+        // The timer belongs to exactly the request selected above or while
+        // draining the control queue.
+        if self.active_reconfig.is_some() {
             self.timers
                 .restart_if_stale(Timer::Reconfig, now, self.rto_mgr.get_rto());
         }
@@ -2856,12 +2881,8 @@ impl Association {
 
     /// pop_pending_data_chunks_to_send pops chunks from the pending queues as many as
     /// the cwnd and rwnd allows to send.
-    fn pop_pending_data_chunks_to_send(
-        &mut self,
-        now: Instant,
-    ) -> (Vec<ChunkPayloadData>, Vec<u16>) {
+    fn pop_pending_data_chunks_to_send(&mut self, now: Instant) -> Vec<ChunkPayloadData> {
         let mut chunks = vec![];
-        let mut sis_to_reset = vec![]; // stream identifiers to reset
         if !self.pending_queue.is_empty() {
             // RFC 4960 sec 6.1.  Transmission of DATA Chunks
             //   A) At any given time, the data sender MUST NOT transmit new data to
@@ -2872,24 +2893,8 @@ impl Association {
             //      the receiver if allowed by cwnd (see rule B, below).
 
             while let Some(c) = self.pending_queue.peek() {
-                let (beginning_fragment, unordered, data_len, stream_identifier) = (
-                    c.beginning_fragment,
-                    c.unordered,
-                    c.user_data.len(),
-                    c.stream_identifier,
-                );
-
-                if data_len == 0 {
-                    sis_to_reset.push(stream_identifier);
-                    if self
-                        .pending_queue
-                        .pop(beginning_fragment, unordered)
-                        .is_none()
-                    {
-                        error!("[{}] failed to pop from pending queue", self.side);
-                    }
-                    continue;
-                }
+                let (beginning_fragment, unordered, data_len) =
+                    (c.beginning_fragment, c.unordered, c.user_data.len());
 
                 if self.inflight_queue.get_num_bytes() + data_len > self.cwnd as usize {
                     break; // would exceeds cwnd
@@ -2927,7 +2932,7 @@ impl Association {
             }
         }
 
-        (chunks, sis_to_reset)
+        chunks
     }
 
     /// bundle_data_chunks_into_packets packs DATA chunks into packets. It tries to bundle
@@ -3134,17 +3139,7 @@ impl Association {
             return Err(Error::ErrResetPacketInStateNotExist);
         }
 
-        // Create DATA chunk which only contains valid stream identifier with
-        // nil userData and use it as a EOS from the stream.
-        let c = ChunkPayloadData {
-            stream_identifier,
-            beginning_fragment: true,
-            ending_fragment: true,
-            user_data: Bytes::new(),
-            ..Default::default()
-        };
-
-        self.pending_queue.push(c);
+        self.pending_reset_streams.push_back(stream_identifier);
         self.awake_write_loop();
 
         Ok(())
@@ -3333,16 +3328,15 @@ impl Association {
             }
 
             Timer::Reconfig => {
-                error!(
-                    "[{}] retransmission failure: Reconfig (clearing {} pending reconfigs)",
-                    self.side,
-                    self.reconfigs.len()
-                );
-                // Abandonment ends the handshake without confirmation from the peer.
-                // Keep the armed completions as quarantine markers so the ids cannot
-                // be reused without a terminal success event.
-                self.reconfigs.clear();
-                self.unsent_reconfigs.clear();
+                if let Some(rsn) = self.active_reconfig {
+                    error!(
+                        "[{}] retransmission failure: Reconfig rsn={}",
+                        self.side, rsn
+                    );
+                    self.finish_reconfig(rsn, Err(StreamResetError::Failed));
+                } else {
+                    self.timers.stop(Timer::Reconfig);
+                }
             }
 
             _ => {}

--- a/src/association/mod.rs
+++ b/src/association/mod.rs
@@ -1871,9 +1871,34 @@ impl Association {
             || current_boundary == self.pending_reset_boundary(stream_identifier)
     }
 
+    fn repeated_ordered_forward_tsn_boundary(
+        &self,
+        stream_identifier: StreamId,
+        last_ssn: u16,
+    ) -> Option<u32> {
+        let boundaries = self.retiring_streams.get(&stream_identifier)?;
+        self.deferred_forward_tsns
+            .get(&stream_identifier)?
+            .iter()
+            .rev()
+            .find_map(|update| match update {
+                DeferredForwardTsn {
+                    generation_boundary: Some(boundary),
+                    kind:
+                        DeferredForwardTsnKind::Ordered {
+                            last_ssn: previous_ssn,
+                        },
+                } if *previous_ssn == last_ssn && boundaries.contains(boundary) => Some(*boundary),
+                _ => None,
+            })
+    }
+
     fn apply_or_defer_ordered_forward_tsn(&mut self, stream_identifier: StreamId, last_ssn: u16) {
         if !self.forward_tsn_applies_to_current_generation(stream_identifier) {
-            let generation_boundary = self.pending_reset_boundary(stream_identifier);
+            let generation_boundary =
+                self.pending_reset_boundary(stream_identifier).or_else(|| {
+                    self.repeated_ordered_forward_tsn_boundary(stream_identifier, last_ssn)
+                });
             self.deferred_forward_tsns
                 .entry(stream_identifier)
                 .or_default()
@@ -2392,9 +2417,10 @@ impl Association {
         // Advance peer_last_tsn
         while sna32lt(self.peer_last_tsn, c.new_cumulative_tsn) {
             let next_tsn = self.peer_last_tsn.wrapping_add(1);
-            if let Some(chunk) = self.payload_queue.pop(next_tsn) {
-                self.deferred_reset_data.remove(&chunk.tsn);
-            }
+            // Keep the reset-generation copy, if any. Applying the stream
+            // forwarding state after replay discards incomplete messages while
+            // preserving complete DATA already received above a TSN gap.
+            let _ = self.payload_queue.pop(next_tsn);
             self.peer_last_tsn = next_tsn;
         }
 
@@ -2451,9 +2477,10 @@ impl Association {
         // Advance peer_last_tsn
         while sna32lt(self.peer_last_tsn, c.new_cumulative_tsn) {
             let next_tsn = self.peer_last_tsn.wrapping_add(1);
-            if let Some(chunk) = self.payload_queue.pop(next_tsn) {
-                self.deferred_reset_data.remove(&chunk.tsn);
-            }
+            // Keep the reset-generation copy, if any. Applying the stream
+            // forwarding state after replay discards incomplete messages while
+            // preserving complete DATA already received above a TSN gap.
+            let _ = self.payload_queue.pop(next_tsn);
             self.peer_last_tsn = next_tsn;
         }
 
@@ -3045,8 +3072,10 @@ impl Association {
             result = ReconfigResult::InProgress;
         }
 
-        // Answer incoming reset requests with the same reset request,
-        // this is the peer's teardown of its own half.
+        // RFC 8831 section 6.7 closes a bidirectional WebRTC data channel by
+        // resetting the corresponding outgoing stream after its incoming half
+        // is reset. `Stream` models that paired channel, so perform the
+        // reciprocal reset automatically.
         //
         // The reciprocal also keeps each unregistered id pending in
         // `reconfigs`, which is what defers `StreamEvent::ResetComplete`
@@ -3785,7 +3814,7 @@ impl Association {
     }
 
     /// create_forward_tsn generates ForwardTSN chunk.
-    /// This method will be be called if use_forward_tsn is set to false.
+    /// This method is called when use_forward_tsn is set to true.
     fn create_forward_tsn(&self) -> ChunkForwardTsn {
         // RFC 3758 Sec 3.5 C4
         let mut stream_map: HashMap<u16, u16> = HashMap::new(); // to report only once per SI

--- a/src/association/mod.rs
+++ b/src/association/mod.rs
@@ -2042,13 +2042,18 @@ impl Association {
         update: DeferredForwardTsn,
     ) -> bool {
         match update.kind {
-            DeferredForwardTsnKind::Ordered { last_ssn, .. } => {
-                self.streams.get(&stream_identifier).is_some_and(|stream| {
-                    stream
-                        .reassembly_queue
-                        .can_apply_forward_tsn_for_ordered_bounded(last_ssn, self.peer_last_tsn)
-                })
-            }
+            DeferredForwardTsnKind::Ordered {
+                last_ssn,
+                new_cumulative_tsn,
+            } => self.streams.get(&stream_identifier).is_some_and(|stream| {
+                stream
+                    .reassembly_queue
+                    .can_apply_forward_tsn_for_ordered_bounded(
+                        last_ssn,
+                        new_cumulative_tsn,
+                        self.peer_last_tsn,
+                    )
+            }),
             DeferredForwardTsnKind::Unordered { .. } => true,
         }
     }

--- a/src/association/mod.rs
+++ b/src/association/mod.rs
@@ -155,6 +155,12 @@ impl PendingResetCompletions {
     }
 }
 
+#[derive(Debug, Copy, Clone)]
+struct DeferredForwardTsn {
+    new_cumulative_tsn: u32,
+    last_ssn: u16,
+}
+
 ///Association represents an SCTP association
 //13.2.  Parameters Necessary per Association (i.e., the TCB)
 //Peer : Tag value to be sent in every packet and is received
@@ -221,9 +227,17 @@ pub struct Association {
     pending_reset_completions: PendingResetCompletions,
     /// Stream ids whose latest completed reset was unsuccessful.
     failed_reset_streams: FxHashSet<StreamId>,
-    /// Old stream generations that have received their final TSN but still
-    /// contain application-readable data.
-    retiring_streams: FxHashSet<StreamId>,
+    /// Reset boundaries for generations that cannot finish until an older
+    /// application-readable generation with the same stream id is drained.
+    retiring_streams: FxHashMap<StreamId, VecDeque<u32>>,
+    /// Number of queued Finished events whose generation has actually drained.
+    ready_stream_finishes: PendingResetCompletions,
+    /// Finished events already delivered to the application and therefore
+    /// eligible to be followed by one terminal reset event.
+    delivered_stream_finishes: PendingResetCompletions,
+    /// Ordered Forward-TSN updates that belong to a successor hidden behind a
+    /// still-readable stream generation.
+    deferred_forward_tsns: FxHashMap<StreamId, VecDeque<DeferredForwardTsn>>,
 
     // Non-RFC internal data
     remote_addr: SocketAddr,
@@ -320,7 +334,10 @@ impl Default for Association {
             peer_reconfig_rsn_initialized: false,
             pending_reset_completions: PendingResetCompletions::default(),
             failed_reset_streams: FxHashSet::default(),
-            retiring_streams: FxHashSet::default(),
+            retiring_streams: FxHashMap::default(),
+            ready_stream_finishes: PendingResetCompletions::default(),
+            delivered_stream_finishes: PendingResetCompletions::default(),
+            deferred_forward_tsns: FxHashMap::default(),
 
             // Non-RFC internal data
             remote_addr: SocketAddr::from_str("0.0.0.0:0").unwrap(),
@@ -588,15 +605,70 @@ impl Association {
     #[must_use]
     pub fn poll(&mut self) -> Option<Event> {
         // A reset boundary can become cumulative after its DATA was made
-        // readable. Keep Finished (and every later event) behind that DATA so
-        // its documented "no more data can be read" guarantee remains true.
-        if let Some(Event::Stream(StreamEvent::Finished { id })) = self.events.front()
-            && self.retiring_streams.contains(id)
-        {
-            return None;
+        // readable. Keep events for that stream generation behind Finished,
+        // while allowing unrelated association and stream events to progress.
+        let mut blocked_streams = FxHashSet::default();
+        let mut selected = None;
+        for (index, event) in self.events.iter().enumerate() {
+            if let Event::Stream(StreamEvent::Finished { id }) = event {
+                if self.state != AssociationState::Closed
+                    && !self.ready_stream_finishes.contains(id)
+                {
+                    blocked_streams.insert(*id);
+                    continue;
+                }
+            }
+
+            if let Event::Stream(stream_event) = event {
+                let stream_id = match stream_event {
+                    StreamEvent::Opened { id }
+                    | StreamEvent::Readable { id }
+                    | StreamEvent::Writable { id }
+                    | StreamEvent::Finished { id }
+                    | StreamEvent::ResetComplete { id }
+                    | StreamEvent::ResetFailed { id, .. }
+                    | StreamEvent::Stopped { id, .. }
+                    | StreamEvent::BufferedAmountLow { id }
+                    | StreamEvent::BufferedAmountHigh { id } => Some(*id),
+                    StreamEvent::Available => None,
+                };
+                if let Some(stream_id) = stream_id {
+                    if blocked_streams.contains(&stream_id) {
+                        let terminal_for_delivered_generation =
+                            matches!(
+                                stream_event,
+                                StreamEvent::ResetComplete { .. } | StreamEvent::ResetFailed { .. }
+                            ) && self.delivered_stream_finishes.contains(&stream_id);
+                        if !terminal_for_delivered_generation {
+                            continue;
+                        }
+                    }
+                }
+            }
+
+            selected = Some(index);
+            break;
         }
 
-        if let Some(x) = self.events.pop_front() {
+        if let Some(index) = selected {
+            let x = self
+                .events
+                .remove(index)
+                .expect("selected event must exist");
+            match &x {
+                Event::Stream(StreamEvent::Finished { id }) => {
+                    self.ready_stream_finishes.take_one(*id);
+                    if self.state != AssociationState::Closed {
+                        self.delivered_stream_finishes.insert(*id);
+                    }
+                }
+                Event::Stream(
+                    StreamEvent::ResetComplete { id } | StreamEvent::ResetFailed { id, .. },
+                ) => {
+                    self.delivered_stream_finishes.take_one(*id);
+                }
+                _ => {}
+            }
             return Some(x);
         }
 
@@ -844,6 +916,9 @@ impl Association {
             self.pending_reset_completions.clear();
             self.failed_reset_streams.clear();
             self.retiring_streams.clear();
+            self.ready_stream_finishes.clear();
+            self.delivered_stream_finishes.clear();
+            self.deferred_forward_tsns.clear();
             self.pending_reset_streams.clear();
             self.reconfigs.clear();
             self.reconfig_requests.clear();
@@ -1037,7 +1112,7 @@ impl Association {
     fn stream_reset_blocked(&self, stream_id: StreamId) -> bool {
         self.pending_reset_completions.contains(&stream_id)
             || self.failed_reset_streams.contains(&stream_id)
-            || self.retiring_streams.contains(&stream_id)
+            || self.retiring_streams.contains_key(&stream_id)
             || self.stream_reset_in_progress(stream_id)
     }
 
@@ -1153,19 +1228,32 @@ impl Association {
             debug!("[{}] unregister_stream {}", self.side, stream_identifier);
             s.state = RecvSendState::Closed;
             if emit_stream_finished {
-                self.events.push_back(Event::Stream(StreamEvent::Finished {
-                    id: stream_identifier,
-                }));
-                // Every Finished owes a terminal reset event, even if the peer
-                // re-creates the stream id before the handshake completes.
-                self.pending_reset_completions.insert(stream_identifier);
+                self.queue_stream_finished(stream_identifier, true);
             }
+        }
+    }
+
+    fn queue_stream_finished(&mut self, stream_identifier: StreamId, ready: bool) {
+        self.events.push_back(Event::Stream(StreamEvent::Finished {
+            id: stream_identifier,
+        }));
+        // Every Finished owes a terminal reset event, even if the peer
+        // re-creates the stream id before the handshake completes.
+        self.pending_reset_completions.insert(stream_identifier);
+        if ready {
+            self.ready_stream_finishes.insert(stream_identifier);
         }
     }
 
     /// Queue the end of an incoming stream generation while preserving any
     /// already-acknowledged DATA until the application drains it.
-    fn retire_stream(&mut self, stream_identifier: StreamId) {
+    fn retire_stream(&mut self, stream_identifier: StreamId, sender_last_tsn: u32) {
+        if let Some(boundaries) = self.retiring_streams.get_mut(&stream_identifier) {
+            boundaries.push_back(sender_last_tsn);
+            self.queue_stream_finished(stream_identifier, false);
+            return;
+        }
+
         let has_unread_data = self
             .streams
             .get(&stream_identifier)
@@ -1176,24 +1264,62 @@ impl Association {
             return;
         }
 
-        if self.retiring_streams.insert(stream_identifier) {
-            self.events.push_back(Event::Stream(StreamEvent::Finished {
-                id: stream_identifier,
-            }));
-            self.pending_reset_completions.insert(stream_identifier);
-        }
+        let mut boundaries = VecDeque::new();
+        boundaries.push_back(sender_last_tsn);
+        self.retiring_streams.insert(stream_identifier, boundaries);
+        self.queue_stream_finished(stream_identifier, false);
     }
 
     /// Drop a drained old generation and release DATA held for its successor.
     pub(crate) fn finish_retiring_stream(&mut self, stream_identifier: StreamId) -> Result<()> {
-        if !self.retiring_streams.remove(&stream_identifier) {
+        if !self.retiring_streams.contains_key(&stream_identifier) {
             return Ok(());
         }
 
         if let Some(mut stream) = self.streams.remove(&stream_identifier) {
             stream.state = RecvSendState::Closed;
         }
-        self.release_deferred_reset_data()
+
+        loop {
+            let (completed_boundary, next_boundary) = {
+                let boundaries = self
+                    .retiring_streams
+                    .get_mut(&stream_identifier)
+                    .expect("retiring stream must retain a boundary");
+                let completed = boundaries
+                    .pop_front()
+                    .expect("retiring stream must have a current generation");
+                (completed, boundaries.front().copied())
+            };
+            self.ready_stream_finishes.insert(stream_identifier);
+
+            let Some(next_boundary) = next_boundary else {
+                self.retiring_streams.remove(&stream_identifier);
+                return self.release_deferred_reset_data();
+            };
+
+            self.release_deferred_generation_data(
+                stream_identifier,
+                completed_boundary,
+                next_boundary,
+            )?;
+
+            let has_unread_data = self
+                .streams
+                .get(&stream_identifier)
+                .is_some_and(|stream| stream.get_num_bytes_in_reassembly_queue() != 0);
+            if has_unread_data {
+                return Ok(());
+            }
+
+            // This generation contained no deliverable DATA. Its already-queued
+            // Finished event can become ready immediately, and any forwarding
+            // state scoped to it must not leak into the following generation.
+            if let Some(mut stream) = self.streams.remove(&stream_identifier) {
+                stream.state = RecvSendState::Closed;
+            }
+            self.discard_deferred_forward_tsns_through(stream_identifier, next_boundary);
+        }
     }
 
     /// set_state atomically sets the state of the Association.
@@ -1639,11 +1765,123 @@ impl Association {
     }
 
     fn data_is_above_pending_reset(&self, d: &ChunkPayloadData) -> bool {
-        self.retiring_streams.contains(&d.stream_identifier)
+        self.retiring_streams.contains_key(&d.stream_identifier)
             || self.reconfig_requests.values().any(|request| {
                 Self::reset_request_affects_stream(request, d.stream_identifier)
                     && sna32gt(d.tsn, request.sender_last_tsn)
             })
+    }
+
+    fn current_reset_boundary(&self, stream_identifier: StreamId) -> Option<u32> {
+        self.retiring_streams
+            .get(&stream_identifier)
+            .and_then(|boundaries| boundaries.front().copied())
+            .or_else(|| {
+                self.reconfig_requests
+                    .values()
+                    .find(|request| Self::reset_request_affects_stream(request, stream_identifier))
+                    .map(|request| request.sender_last_tsn)
+            })
+    }
+
+    fn forward_tsn_applies_to_current_generation(
+        &self,
+        stream_identifier: StreamId,
+        new_cumulative_tsn: u32,
+    ) -> bool {
+        self.current_reset_boundary(stream_identifier)
+            .is_none_or(|boundary| sna32lte(new_cumulative_tsn, boundary))
+    }
+
+    fn apply_or_defer_ordered_forward_tsn(
+        &mut self,
+        stream_identifier: StreamId,
+        new_cumulative_tsn: u32,
+        last_ssn: u16,
+    ) {
+        if !self.forward_tsn_applies_to_current_generation(stream_identifier, new_cumulative_tsn) {
+            self.deferred_forward_tsns
+                .entry(stream_identifier)
+                .or_default()
+                .push_back(DeferredForwardTsn {
+                    new_cumulative_tsn,
+                    last_ssn,
+                });
+            return;
+        }
+
+        if let Some(stream) = self.streams.get_mut(&stream_identifier) {
+            stream.handle_forward_tsn_for_ordered(last_ssn);
+        }
+    }
+
+    fn apply_unordered_forward_tsn_to_current_streams(&mut self, new_cumulative_tsn: u32) {
+        let stream_ids: Vec<StreamId> = self
+            .streams
+            .keys()
+            .copied()
+            .filter(|stream_identifier| {
+                self.forward_tsn_applies_to_current_generation(
+                    *stream_identifier,
+                    new_cumulative_tsn,
+                )
+            })
+            .collect();
+        for stream_identifier in stream_ids {
+            if let Some(stream) = self.streams.get_mut(&stream_identifier) {
+                stream.handle_forward_tsn_for_unordered(new_cumulative_tsn);
+            }
+        }
+    }
+
+    fn apply_deferred_forward_tsns(&mut self, stream_identifier: StreamId) {
+        if !self.streams.contains_key(&stream_identifier) {
+            return;
+        }
+
+        let boundary = self.current_reset_boundary(stream_identifier);
+        let ready: Vec<DeferredForwardTsn> = self
+            .deferred_forward_tsns
+            .get(&stream_identifier)
+            .into_iter()
+            .flatten()
+            .filter(|update| {
+                boundary.is_none_or(|boundary| sna32lte(update.new_cumulative_tsn, boundary))
+            })
+            .copied()
+            .collect();
+
+        if ready.is_empty() {
+            return;
+        }
+
+        if let Some(updates) = self.deferred_forward_tsns.get_mut(&stream_identifier) {
+            updates.retain(|update| {
+                boundary.is_some_and(|boundary| sna32gt(update.new_cumulative_tsn, boundary))
+            });
+            if updates.is_empty() {
+                self.deferred_forward_tsns.remove(&stream_identifier);
+            }
+        }
+
+        if let Some(stream) = self.streams.get_mut(&stream_identifier) {
+            for update in ready {
+                stream.handle_forward_tsn_for_ordered(update.last_ssn);
+            }
+        }
+    }
+
+    fn discard_deferred_forward_tsns_through(
+        &mut self,
+        stream_identifier: StreamId,
+        boundary: u32,
+    ) {
+        if let Some(updates) = self.deferred_forward_tsns.get_mut(&stream_identifier) {
+            updates.retain(|update| sna32gt(update.new_cumulative_tsn, boundary));
+            if updates.is_empty() {
+                self.deferred_forward_tsns.remove(&stream_identifier);
+            }
+        }
     }
 
     fn deliver_deferred_reset_data(&mut self, d: &ChunkPayloadData) -> Result<()> {
@@ -1651,6 +1889,7 @@ impl Association {
             debug!("[{}] discard {}", self.side, d.stream_sequence_number);
             return Ok(());
         }
+        self.apply_deferred_forward_tsns(d.stream_identifier);
 
         if let Some(stream) = self.streams.get_mut(&d.stream_identifier) {
             let queued = stream.handle_data(d)?;
@@ -1660,6 +1899,32 @@ impl Association {
                     id: d.stream_identifier,
                 }));
             }
+        }
+
+        Ok(())
+    }
+
+    fn release_deferred_generation_data(
+        &mut self,
+        stream_identifier: StreamId,
+        previous_boundary: u32,
+        boundary: u32,
+    ) -> Result<()> {
+        let mut ready: Vec<ChunkPayloadData> = self
+            .deferred_reset_data
+            .values()
+            .filter(|chunk| {
+                chunk.stream_identifier == stream_identifier
+                    && sna32gt(chunk.tsn, previous_boundary)
+                    && sna32lte(chunk.tsn, boundary)
+            })
+            .cloned()
+            .collect();
+        ready.sort_unstable_by_key(|chunk| chunk.tsn.wrapping_sub(previous_boundary));
+
+        for chunk in ready {
+            self.deliver_deferred_reset_data(&chunk)?;
+            self.deferred_reset_data.remove(&chunk.tsn);
         }
 
         Ok(())
@@ -1709,6 +1974,7 @@ impl Association {
             }
         } else if can_push {
             if self.get_or_create_stream(d.stream_identifier).is_some() {
+                self.apply_deferred_forward_tsns(d.stream_identifier);
                 if self.get_my_receiver_window_credit() > 0 {
                     // Pass the new chunk to stream level as soon as it arrives
                     stream_handle_data = true;
@@ -1963,9 +2229,11 @@ impl Association {
         // corresponding streams so that the abandoned chunks can be removed
         // from the reassemblyQueue.
         for forwarded in &c.streams {
-            if let Some(s) = self.streams.get_mut(&forwarded.identifier) {
-                s.handle_forward_tsn_for_ordered(forwarded.sequence);
-            }
+            self.apply_or_defer_ordered_forward_tsn(
+                forwarded.identifier,
+                c.new_cumulative_tsn,
+                forwarded.sequence,
+            );
         }
 
         // TSN may be forewared for unordered chunks. ForwardTSN chunk does not
@@ -1973,9 +2241,7 @@ impl Association {
         // Therefore, we need to broadcast this event to all existing streams for
         // unordered chunks.
         // See https://github.com/pion/sctp/issues/106
-        for s in self.streams.values_mut() {
-            s.handle_forward_tsn_for_unordered(c.new_cumulative_tsn);
-        }
+        self.apply_unordered_forward_tsn_to_current_streams(c.new_cumulative_tsn);
 
         let mut reply = vec![];
         self.reevaluate_pending_reset_requests(&mut reply)?;
@@ -2025,21 +2291,26 @@ impl Association {
         // Handle per-stream entries using the explicit unordered flag
         for forwarded in &c.streams {
             if forwarded.unordered {
-                if let Some(s) = self.streams.get_mut(&forwarded.identifier) {
-                    s.handle_forward_tsn_for_unordered(c.new_cumulative_tsn);
+                if self.forward_tsn_applies_to_current_generation(
+                    forwarded.identifier,
+                    c.new_cumulative_tsn,
+                ) {
+                    if let Some(s) = self.streams.get_mut(&forwarded.identifier) {
+                        s.handle_forward_tsn_for_unordered(c.new_cumulative_tsn);
+                    }
                 }
             } else {
                 // MID maps to SSN for ordered streams; truncate to u16
-                if let Some(s) = self.streams.get_mut(&forwarded.identifier) {
-                    s.handle_forward_tsn_for_ordered(forwarded.mid as u16);
-                }
+                self.apply_or_defer_ordered_forward_tsn(
+                    forwarded.identifier,
+                    c.new_cumulative_tsn,
+                    forwarded.mid as u16,
+                );
             }
         }
 
         // Broadcast to all unordered streams
-        for s in self.streams.values_mut() {
-            s.handle_forward_tsn_for_unordered(c.new_cumulative_tsn);
-        }
+        self.apply_unordered_forward_tsn_to_current_streams(c.new_cumulative_tsn);
 
         let mut reply = vec![];
         self.reevaluate_pending_reset_requests(&mut reply)?;
@@ -2599,7 +2870,7 @@ impl Association {
             for id in stream_ids {
                 if self.streams.contains_key(&id) {
                     sis_to_reset.push(id);
-                    self.retire_stream(id);
+                    self.retire_stream(id, p.sender_last_tsn);
                 }
             }
             self.reconfig_requests

--- a/src/association/mod.rs
+++ b/src/association/mod.rs
@@ -205,19 +205,25 @@ pub struct Association {
     /// Application-initiated resets waiting for the active request to finish.
     pending_reset_streams: VecDeque<StreamId>,
     reconfig_requests: FxHashMap<u32, ParamOutgoingResetRequest>,
-    /// DATA received above an InProgress reset boundary. The chunks remain in
-    /// `payload_queue` for TSN accounting but are withheld from stream
-    /// reassembly until the reset creates the next stream generation.
-    deferred_reset_tsns: FxHashSet<u32>,
+    /// DATA received above an InProgress reset boundary. A copy is retained
+    /// after cumulative TSN processing removes it from `payload_queue`, so it
+    /// can remain withheld until the old stream generation is drained.
+    deferred_reset_data: FxHashMap<u32, ChunkPayloadData>,
     max_completed_reconfig_rsn: Option<u32>,
     /// Re-configuration Request Sequence Number most recently accepted from
     /// the peer, initialized to the peer's initial TSN minus one.
     peer_last_reconfig_rsn: u32,
-    /// Stream ids for which `StreamEvent::Finished` has fired but whose terminal
+    /// Whether `peer_last_reconfig_rsn` has been initialized from an INIT or a
+    /// first request in test/manual construction.
+    peer_reconfig_rsn_initialized: bool,
+    /// Stream ids for which `StreamEvent::Finished` is queued but whose terminal
     /// reset event is still awaited.
     pending_reset_completions: PendingResetCompletions,
     /// Stream ids whose latest completed reset was unsuccessful.
     failed_reset_streams: FxHashSet<StreamId>,
+    /// Old stream generations that have received their final TSN but still
+    /// contain application-readable data.
+    retiring_streams: FxHashSet<StreamId>,
 
     // Non-RFC internal data
     remote_addr: SocketAddr,
@@ -308,11 +314,13 @@ impl Default for Association {
             active_reconfig: None,
             pending_reset_streams: VecDeque::default(),
             reconfig_requests: FxHashMap::default(),
-            deferred_reset_tsns: FxHashSet::default(),
+            deferred_reset_data: FxHashMap::default(),
             max_completed_reconfig_rsn: None,
             peer_last_reconfig_rsn: 0,
+            peer_reconfig_rsn_initialized: false,
             pending_reset_completions: PendingResetCompletions::default(),
             failed_reset_streams: FxHashSet::default(),
+            retiring_streams: FxHashSet::default(),
 
             // Non-RFC internal data
             remote_addr: SocketAddr::from_str("0.0.0.0:0").unwrap(),
@@ -579,6 +587,15 @@ impl Association {
     /// - a call was made to `handle_timeout`
     #[must_use]
     pub fn poll(&mut self) -> Option<Event> {
+        // A reset boundary can become cumulative after its DATA was made
+        // readable. Keep Finished (and every later event) behind that DATA so
+        // its documented "no more data can be read" guarantee remains true.
+        if let Some(Event::Stream(StreamEvent::Finished { id })) = self.events.front()
+            && self.retiring_streams.contains(id)
+        {
+            return None;
+        }
+
         if let Some(x) = self.events.pop_front() {
             return Some(x);
         }
@@ -826,10 +843,11 @@ impl Association {
             // AssociationLost stops any pending  ResetComplete.
             self.pending_reset_completions.clear();
             self.failed_reset_streams.clear();
+            self.retiring_streams.clear();
             self.pending_reset_streams.clear();
             self.reconfigs.clear();
             self.reconfig_requests.clear();
-            self.deferred_reset_tsns.clear();
+            self.deferred_reset_data.clear();
             self.control_queue.clear();
             self.active_reconfig = None;
             self.will_retransmit_reconfig = false;
@@ -1019,6 +1037,7 @@ impl Association {
     fn stream_reset_blocked(&self, stream_id: StreamId) -> bool {
         self.pending_reset_completions.contains(&stream_id)
             || self.failed_reset_streams.contains(&stream_id)
+            || self.retiring_streams.contains(&stream_id)
             || self.stream_reset_in_progress(stream_id)
     }
 
@@ -1144,6 +1163,39 @@ impl Association {
         }
     }
 
+    /// Queue the end of an incoming stream generation while preserving any
+    /// already-acknowledged DATA until the application drains it.
+    fn retire_stream(&mut self, stream_identifier: StreamId) {
+        let has_unread_data = self
+            .streams
+            .get(&stream_identifier)
+            .is_some_and(|stream| stream.get_num_bytes_in_reassembly_queue() != 0);
+
+        if !has_unread_data {
+            self.unregister_stream(stream_identifier, true);
+            return;
+        }
+
+        if self.retiring_streams.insert(stream_identifier) {
+            self.events.push_back(Event::Stream(StreamEvent::Finished {
+                id: stream_identifier,
+            }));
+            self.pending_reset_completions.insert(stream_identifier);
+        }
+    }
+
+    /// Drop a drained old generation and release DATA held for its successor.
+    pub(crate) fn finish_retiring_stream(&mut self, stream_identifier: StreamId) -> Result<()> {
+        if !self.retiring_streams.remove(&stream_identifier) {
+            return Ok(());
+        }
+
+        if let Some(mut stream) = self.streams.remove(&stream_identifier) {
+            stream.state = RecvSendState::Closed;
+        }
+        self.release_deferred_reset_data()
+    }
+
     /// set_state atomically sets the state of the Association.
     fn set_state(&mut self, new_state: AssociationState) {
         if new_state != self.state {
@@ -1178,6 +1230,7 @@ impl Association {
         // RFC 6525 §4: the peer's first request sequence number is its initial
         // TSN, so A4's initial response value is one less than that.
         self.peer_last_reconfig_rsn = initial_tsn.wrapping_sub(1);
+        self.peer_reconfig_rsn_initialized = true;
 
         self.rwnd = advertised_receiver_window_credit;
         debug!("[{}] initial rwnd={}", self.side, self.rwnd);
@@ -1586,10 +1639,11 @@ impl Association {
     }
 
     fn data_is_above_pending_reset(&self, d: &ChunkPayloadData) -> bool {
-        self.reconfig_requests.values().any(|request| {
-            Self::reset_request_affects_stream(request, d.stream_identifier)
-                && sna32gt(d.tsn, request.sender_last_tsn)
-        })
+        self.retiring_streams.contains(&d.stream_identifier)
+            || self.reconfig_requests.values().any(|request| {
+                Self::reset_request_affects_stream(request, d.stream_identifier)
+                    && sna32gt(d.tsn, request.sender_last_tsn)
+            })
     }
 
     fn deliver_deferred_reset_data(&mut self, d: &ChunkPayloadData) -> Result<()> {
@@ -1613,16 +1667,15 @@ impl Association {
 
     fn release_deferred_reset_data(&mut self) -> Result<()> {
         let ready: Vec<ChunkPayloadData> = self
-            .deferred_reset_tsns
-            .iter()
-            .filter_map(|tsn| self.payload_queue.get(*tsn))
+            .deferred_reset_data
+            .values()
             .filter(|chunk| !self.data_is_above_pending_reset(chunk))
             .cloned()
             .collect();
 
         for chunk in ready {
             self.deliver_deferred_reset_data(&chunk)?;
-            self.deferred_reset_tsns.remove(&chunk.tsn);
+            self.deferred_reset_data.remove(&chunk.tsn);
         }
 
         Ok(())
@@ -1689,7 +1742,7 @@ impl Association {
 
         if defer_stream_data {
             if self.payload_queue.push(d.clone(), self.peer_last_tsn) {
-                self.deferred_reset_tsns.insert(d.tsn);
+                self.deferred_reset_data.insert(d.tsn, d.clone());
             }
         } else if stream_handle_data {
             if let Some(s) = self.streams.get_mut(&d.stream_identifier) {
@@ -1901,7 +1954,7 @@ impl Association {
         while sna32lt(self.peer_last_tsn, c.new_cumulative_tsn) {
             let next_tsn = self.peer_last_tsn.wrapping_add(1);
             if let Some(chunk) = self.payload_queue.pop(next_tsn) {
-                self.deferred_reset_tsns.remove(&chunk.tsn);
+                self.deferred_reset_data.remove(&chunk.tsn);
             }
             self.peer_last_tsn = next_tsn;
         }
@@ -1964,7 +2017,7 @@ impl Association {
         while sna32lt(self.peer_last_tsn, c.new_cumulative_tsn) {
             let next_tsn = self.peer_last_tsn.wrapping_add(1);
             if let Some(chunk) = self.payload_queue.pop(next_tsn) {
-                self.deferred_reset_tsns.remove(&chunk.tsn);
+                self.deferred_reset_data.remove(&chunk.tsn);
             }
             self.peer_last_tsn = next_tsn;
         }
@@ -2075,8 +2128,11 @@ impl Association {
 
             self.reevaluate_pending_reset_requests(&mut reply)?;
 
-            if self.deferred_reset_tsns.remove(&chunk.tsn) {
-                self.deliver_deferred_reset_data(&chunk)?;
+            if let Some(deferred) = self.deferred_reset_data.get(&chunk.tsn).cloned() {
+                if !self.data_is_above_pending_reset(&deferred) {
+                    self.deliver_deferred_reset_data(&deferred)?;
+                    self.deferred_reset_data.remove(&chunk.tsn);
+                }
             }
         }
 
@@ -2130,20 +2186,41 @@ impl Association {
             {
                 // Retransmission of an already-completed request. Resend the response
                 // but do NOT reprocess stream resets (stream IDs may have been reused).
-                let packet = self.create_packet(vec![Box::new(ChunkReconfig {
-                    param_a: Some(Box::new(ParamReconfigResponse {
-                        reconfig_response_sequence_number: seq,
-                        result: ReconfigResult::SuccessPerformed,
-                    })),
-                    param_b: None,
-                })]);
-                reply.push(packet);
+                self.push_reconfig_response(reply, seq, ReconfigResult::SuccessPerformed);
                 return Ok(());
             }
-            self.peer_last_reconfig_rsn = seq;
-            self.reconfig_requests
-                .insert(p.reconfig_request_sequence_number, p.clone());
-            self.reset_streams_if_any(p, true, reply)?;
+
+            if !self.reconfig_requests.contains_key(&seq) {
+                // RFC 6525 section 5.2.2 E4: only the next expected peer
+                // request sequence number may start a new operation. A request
+                // already deferred in reconfig_requests is a retransmission and
+                // remains eligible for re-evaluation.
+                if !self.reconfig_requests.is_empty() {
+                    self.push_reconfig_response(
+                        reply,
+                        seq,
+                        ReconfigResult::ErrorRequestAlreadyInProgress,
+                    );
+                    return Ok(());
+                }
+
+                if self.peer_reconfig_rsn_initialized
+                    && seq != self.peer_last_reconfig_rsn.wrapping_add(1)
+                {
+                    self.push_reconfig_response(reply, seq, ReconfigResult::ErrorBadSequenceNumber);
+                    return Ok(());
+                }
+
+                self.peer_last_reconfig_rsn = seq;
+                self.peer_reconfig_rsn_initialized = true;
+                self.reconfig_requests.insert(seq, p.clone());
+            }
+
+            // Re-evaluate the original request for this RSN. This prevents a
+            // retransmission with altered stream identifiers or TSN boundary
+            // from changing an operation that is already in progress.
+            let request = self.reconfig_requests.get(&seq).cloned().unwrap();
+            self.reset_streams_if_any(&request, true, reply)?;
             // Update watermark only after successful completion (request
             // removed from reconfig_requests by reset_streams_if_any).
             if !self.reconfig_requests.contains_key(&seq) {
@@ -2182,6 +2259,21 @@ impl Association {
         } else {
             Err(Error::ErrParameterType)
         }
+    }
+
+    fn push_reconfig_response(
+        &self,
+        reply: &mut Vec<Packet>,
+        sequence_number: u32,
+        result: ReconfigResult,
+    ) {
+        reply.push(self.create_packet(vec![Box::new(ChunkReconfig {
+            param_a: Some(Box::new(ParamReconfigResponse {
+                reconfig_response_sequence_number: sequence_number,
+                result,
+            })),
+            param_b: None,
+        })]));
     }
 
     fn process_selective_ack(
@@ -2507,7 +2599,7 @@ impl Association {
             for id in stream_ids {
                 if self.streams.contains_key(&id) {
                     sis_to_reset.push(id);
-                    self.unregister_stream(id, true);
+                    self.retire_stream(id);
                 }
             }
             self.reconfig_requests
@@ -2640,10 +2732,8 @@ impl Association {
         for s in self.streams.values() {
             bytes_queued += s.get_num_bytes_in_reassembly_queue() as u32;
         }
-        for tsn in &self.deferred_reset_tsns {
-            if let Some(chunk) = self.payload_queue.get(*tsn) {
-                bytes_queued += chunk.user_data.len() as u32;
-            }
+        for chunk in self.deferred_reset_data.values() {
+            bytes_queued += chunk.user_data.len() as u32;
         }
 
         self.max_receive_buffer_size.saturating_sub(bytes_queued)

--- a/src/association/mod.rs
+++ b/src/association/mod.rs
@@ -216,6 +216,10 @@ pub struct Association {
     // Reconfig
     my_next_rsn: u32,
     reconfigs: FxHashMap<u32, ChunkReconfig>,
+    /// Stream ids semantically covered by an outgoing reset. Reset-all stays
+    /// compact on the wire, so its completion ids cannot be recovered from the
+    /// serialized parameter itself.
+    reconfig_reset_streams: FxHashMap<u32, Vec<StreamId>>,
     /// The one request whose Re-configuration Timer is running.
     active_reconfig: Option<u32>,
     /// Application-initiated resets waiting for the active request to finish.
@@ -245,7 +249,7 @@ pub struct Association {
     /// Finished events already delivered to the application and therefore
     /// eligible to be followed by one terminal reset event.
     delivered_stream_finishes: PendingResetCompletions,
-    /// Ordered Forward-TSN updates that belong to a successor hidden behind a
+    /// Forward-TSN updates that belong to a successor hidden behind a
     /// still-readable stream generation.
     deferred_forward_tsns: FxHashMap<StreamId, VecDeque<DeferredForwardTsn>>,
 
@@ -335,6 +339,7 @@ impl Default for Association {
             // Reconfig
             my_next_rsn: 0,
             reconfigs: FxHashMap::default(),
+            reconfig_reset_streams: FxHashMap::default(),
             active_reconfig: None,
             pending_reset_streams: VecDeque::default(),
             reconfig_requests: FxHashMap::default(),
@@ -935,6 +940,7 @@ impl Association {
             self.deferred_forward_tsns.clear();
             self.pending_reset_streams.clear();
             self.reconfigs.clear();
+            self.reconfig_reset_streams.clear();
             self.reconfig_requests.clear();
             self.deferred_reset_data.clear();
             self.control_queue.clear();
@@ -1074,8 +1080,18 @@ impl Association {
             // Requests are serialized, so a success supersedes any older failure
             // for the same stream id. A newer pending generation still blocks reuse.
             self.failed_reset_streams.remove(&id);
-            if !self.stream_reset_blocked(id) {
-                if let Some(stream) = self.streams.get_mut(&id) {
+            let reset_blocked = self.stream_reset_blocked(id);
+            if !reset_blocked {
+                let application_closed = notify
+                    && self.streams.get(&id).is_some_and(|stream| {
+                        matches!(
+                            stream.state,
+                            RecvSendState::Closed | RecvSendState::Writable
+                        )
+                    });
+                if application_closed {
+                    self.unregister_stream(id, false);
+                } else if let Some(stream) = self.streams.get_mut(&id) {
                     // RFC 6525 section 5.2.7 H4 resets the outgoing SSN. Do not
                     // alter `state`: a protocol reset must never undo an
                     // application-level `Stream::finish()`.
@@ -1216,11 +1232,15 @@ impl Association {
             return false;
         }
 
-        let ids = self
+        let fallback_ids = self
             .reconfigs
             .remove(&rsn)
             .map(|c| Self::reconfig_stream_ids(&c))
             .unwrap_or_default();
+        let ids = self
+            .reconfig_reset_streams
+            .remove(&rsn)
+            .unwrap_or(fallback_ids);
         self.active_reconfig = None;
         self.will_retransmit_reconfig = false;
         self.timers.stop(Timer::Reconfig);
@@ -1871,41 +1891,22 @@ impl Association {
             || current_boundary == self.pending_reset_boundary(stream_identifier)
     }
 
-    fn repeated_ordered_forward_tsn_boundary(
-        &self,
-        stream_identifier: StreamId,
-        last_ssn: u16,
-    ) -> Option<u32> {
-        let boundaries = self.retiring_streams.get(&stream_identifier)?;
-        self.deferred_forward_tsns
-            .get(&stream_identifier)?
-            .iter()
-            .rev()
-            .find_map(|update| match update {
-                DeferredForwardTsn {
-                    generation_boundary: Some(boundary),
-                    kind:
-                        DeferredForwardTsnKind::Ordered {
-                            last_ssn: previous_ssn,
-                        },
-                } if *previous_ssn == last_ssn && boundaries.contains(boundary) => Some(*boundary),
-                _ => None,
-            })
-    }
-
     fn apply_or_defer_ordered_forward_tsn(&mut self, stream_identifier: StreamId, last_ssn: u16) {
         if !self.forward_tsn_applies_to_current_generation(stream_identifier) {
-            let generation_boundary =
-                self.pending_reset_boundary(stream_identifier).or_else(|| {
-                    self.repeated_ordered_forward_tsn_boundary(stream_identifier, last_ssn)
-                });
+            let generation_boundary = self.pending_reset_boundary(stream_identifier);
+            let kind = DeferredForwardTsnKind::Ordered { last_ssn };
             self.deferred_forward_tsns
                 .entry(stream_identifier)
                 .or_default()
                 .push_back(DeferredForwardTsn {
                     generation_boundary,
-                    kind: DeferredForwardTsnKind::Ordered { last_ssn },
+                    kind,
                 });
+            self.prune_deferred_reset_data_for_forward_tsn(
+                stream_identifier,
+                generation_boundary,
+                kind,
+            );
             return;
         }
 
@@ -1931,13 +1932,41 @@ impl Association {
     ) {
         if !self.forward_tsn_applies_to_current_generation(stream_identifier) {
             let generation_boundary = self.pending_reset_boundary(stream_identifier);
-            self.deferred_forward_tsns
-                .entry(stream_identifier)
-                .or_default()
-                .push_back(DeferredForwardTsn {
-                    generation_boundary,
-                    kind: DeferredForwardTsnKind::Unordered { new_cumulative_tsn },
-                });
+            let effective_cumulative_tsn = {
+                let updates = self
+                    .deferred_forward_tsns
+                    .entry(stream_identifier)
+                    .or_default();
+                if let Some(previous_cumulative_tsn) = updates.iter_mut().find_map(|update| {
+                    if update.generation_boundary != generation_boundary {
+                        return None;
+                    }
+                    match &mut update.kind {
+                        DeferredForwardTsnKind::Unordered { new_cumulative_tsn } => {
+                            Some(new_cumulative_tsn)
+                        }
+                        DeferredForwardTsnKind::Ordered { .. } => None,
+                    }
+                }) {
+                    if sna32lt(*previous_cumulative_tsn, new_cumulative_tsn) {
+                        *previous_cumulative_tsn = new_cumulative_tsn;
+                    }
+                    *previous_cumulative_tsn
+                } else {
+                    updates.push_back(DeferredForwardTsn {
+                        generation_boundary,
+                        kind: DeferredForwardTsnKind::Unordered { new_cumulative_tsn },
+                    });
+                    new_cumulative_tsn
+                }
+            };
+            self.prune_deferred_reset_data_for_forward_tsn(
+                stream_identifier,
+                generation_boundary,
+                DeferredForwardTsnKind::Unordered {
+                    new_cumulative_tsn: effective_cumulative_tsn,
+                },
+            );
             return;
         }
 
@@ -2019,6 +2048,66 @@ impl Association {
         }
     }
 
+    /// Release receive-window credit for incomplete successor messages that a
+    /// deferred Forward-TSN has abandoned. Complete messages remain available
+    /// when that stream generation is eventually exposed to the application.
+    fn prune_deferred_reset_data_for_forward_tsn(
+        &mut self,
+        stream_identifier: StreamId,
+        generation_boundary: Option<u32>,
+        kind: DeferredForwardTsnKind,
+    ) {
+        let mut chunks: Vec<ChunkPayloadData> = self
+            .deferred_reset_data
+            .values()
+            .filter(|chunk| {
+                chunk.stream_identifier == stream_identifier
+                    && self
+                        .deferred_generation_bounds(stream_identifier, chunk.tsn)
+                        .is_some_and(|(_, upper)| upper == generation_boundary)
+            })
+            .cloned()
+            .collect();
+        if chunks.is_empty() {
+            return;
+        }
+
+        chunks.sort_unstable_by_key(|chunk| {
+            self.deferred_generation_bounds(stream_identifier, chunk.tsn)
+                .map(|(lower, _)| chunk.tsn.wrapping_sub(lower))
+                .unwrap_or_default()
+        });
+        let targeted_tsns: FxHashSet<u32> = chunks.iter().map(|chunk| chunk.tsn).collect();
+
+        let mut queue = ReassemblyQueue::new(stream_identifier, self.max_receive_message_size);
+        for chunk in chunks {
+            // These chunks were validated before being retained. If rebuilding
+            // their generation unexpectedly fails, keep the data conservatively.
+            if queue.push(chunk).is_err() {
+                return;
+            }
+        }
+        match kind {
+            DeferredForwardTsnKind::Ordered { last_ssn } => {
+                queue.forward_tsn_for_ordered(last_ssn);
+            }
+            DeferredForwardTsnKind::Unordered { new_cumulative_tsn } => {
+                queue.forward_tsn_for_unordered(new_cumulative_tsn);
+            }
+        }
+
+        let retained_tsns: FxHashSet<u32> = queue
+            .ordered
+            .iter()
+            .chain(&queue.unordered)
+            .flat_map(|chunks| chunks.chunks.iter())
+            .chain(queue.unordered_chunks.iter())
+            .map(|chunk| chunk.tsn)
+            .collect();
+        self.deferred_reset_data
+            .retain(|tsn, _| !targeted_tsns.contains(tsn) || retained_tsns.contains(tsn));
+    }
+
     fn deliver_deferred_reset_data(&mut self, d: &ChunkPayloadData) -> Result<()> {
         if self.get_or_create_stream(d.stream_identifier).is_none() {
             debug!("[{}] discard {}", self.side, d.stream_sequence_number);
@@ -2081,8 +2170,10 @@ impl Association {
             .into_iter()
             .flat_map(|boundaries| boundaries.iter().copied())
             .collect();
-        if boundaries.is_empty() {
-            boundaries.extend(pending_boundary);
+        if let Some(pending_boundary) = pending_boundary {
+            if boundaries.last().copied() != Some(pending_boundary) {
+                boundaries.push(pending_boundary);
+            }
         }
 
         let mut lower = *boundaries.first()?;
@@ -2171,7 +2262,6 @@ impl Association {
             }
         } else if can_push {
             if self.get_or_create_stream(d.stream_identifier).is_some() {
-                self.apply_deferred_forward_tsns(d.stream_identifier);
                 if self.get_my_receiver_window_credit() > 0 {
                     // Pass the new chunk to stream level as soon as it arrives
                     stream_handle_data = true;
@@ -2220,6 +2310,10 @@ impl Association {
                     }))
                 }
             }
+            // A deferred skip may describe this successor generation. Queue
+            // DATA first so a complete message reusing the skipped SSN remains
+            // readable, while a genuinely abandoned SSN can still be advanced.
+            self.apply_deferred_forward_tsns(d.stream_identifier);
         }
 
         self.handle_peer_last_tsn_and_acknowledgement(immediate_sack)
@@ -2431,7 +2525,7 @@ impl Association {
             self.apply_or_defer_ordered_forward_tsn(forwarded.identifier, forwarded.sequence);
         }
 
-        // TSN may be forewared for unordered chunks. ForwardTSN chunk does not
+        // TSN may be forwarded for unordered chunks. ForwardTSN chunk does not
         // report which stream identifier it skipped for unordered chunks.
         // Therefore, we need to broadcast this event to all existing streams for
         // unordered chunks.
@@ -2699,6 +2793,7 @@ impl Association {
             // without counting toward the retransmission limit.
             if p.result == ReconfigResult::InProgress {
                 if self.reconfigs.contains_key(&rsn) {
+                    self.will_retransmit_reconfig = false;
                     // Pause without resetting the existing retry count. The outbound
                     // poll starts it again and the next expiry is exempted by H2.
                     self.timers.set(Timer::Reconfig, None);
@@ -3084,13 +3179,16 @@ impl Association {
         if !sis_to_reset.is_empty() {
             let rsn = self.generate_next_rsn();
             let tsn = self.my_next_tsn.wrapping_sub(1);
+            let reset_all = p.stream_identifiers.is_empty();
+            self.reconfig_reset_streams
+                .insert(rsn, sis_to_reset.clone());
 
             let c = ChunkReconfig {
                 param_a: Some(Box::new(ParamOutgoingResetRequest {
                     reconfig_request_sequence_number: rsn,
                     reconfig_response_sequence_number: p.reconfig_request_sequence_number,
                     sender_last_tsn: tsn,
-                    stream_identifiers: sis_to_reset,
+                    stream_identifiers: if reset_all { vec![] } else { sis_to_reset },
                 })),
                 ..Default::default()
             };
@@ -3392,6 +3490,7 @@ impl Association {
                 self.side, rsn, tsn, stream_ids
             );
 
+            self.reconfig_reset_streams.insert(rsn, stream_ids.clone());
             let c = ChunkReconfig {
                 param_a: Some(Box::new(ParamOutgoingResetRequest {
                     reconfig_request_sequence_number: rsn,

--- a/src/association/mod.rs
+++ b/src/association/mod.rs
@@ -206,6 +206,9 @@ pub struct Association {
     pending_reset_streams: VecDeque<StreamId>,
     reconfig_requests: FxHashMap<u32, ParamOutgoingResetRequest>,
     max_completed_reconfig_rsn: Option<u32>,
+    /// Re-configuration Request Sequence Number most recently accepted from
+    /// the peer, initialized to the peer's initial TSN minus one.
+    peer_last_reconfig_rsn: u32,
     /// Stream ids for which `StreamEvent::Finished` has fired but whose terminal
     /// reset event is still awaited.
     pending_reset_completions: PendingResetCompletions,
@@ -302,6 +305,7 @@ impl Default for Association {
             pending_reset_streams: VecDeque::default(),
             reconfig_requests: FxHashMap::default(),
             max_completed_reconfig_rsn: None,
+            peer_last_reconfig_rsn: 0,
             pending_reset_completions: PendingResetCompletions::default(),
             failed_reset_streams: FxHashSet::default(),
 
@@ -818,7 +822,11 @@ impl Association {
             self.pending_reset_completions.clear();
             self.failed_reset_streams.clear();
             self.pending_reset_streams.clear();
+            self.reconfigs.clear();
+            self.reconfig_requests.clear();
+            self.control_queue.clear();
             self.active_reconfig = None;
+            self.will_retransmit_reconfig = false;
 
             self.events.push_back(Event::AssociationLost {
                 reason: AssociationError::AssociationClosed,
@@ -955,9 +963,10 @@ impl Association {
             self.failed_reset_streams.remove(&id);
             if !self.stream_reset_blocked(id) {
                 if let Some(stream) = self.streams.get_mut(&id) {
-                    if stream.state == RecvSendState::Readable {
-                        stream.state = RecvSendState::ReadWritable;
-                    }
+                    // RFC 6525 section 5.2.7 H4 resets the outgoing SSN. Do not
+                    // alter `state`: a protocol reset must never undo an
+                    // application-level `Stream::finish()`.
+                    stream.sequence_number = 0;
                 }
             }
             if notify {
@@ -1029,6 +1038,46 @@ impl Association {
                         .map(|request| request.reconfig_request_sequence_number)
                 })
         })
+    }
+
+    fn reconfig_with_sender_last_tsn(c: &ChunkReconfig, sender_last_tsn: u32) -> ChunkReconfig {
+        fn update(
+            param: &Option<Box<dyn Param + Send + Sync>>,
+            sender_last_tsn: u32,
+        ) -> Option<Box<dyn Param + Send + Sync>> {
+            param.as_ref().map(|param| {
+                if let Some(request) = param.as_any().downcast_ref::<ParamOutgoingResetRequest>() {
+                    let mut request = request.clone();
+                    request.sender_last_tsn = sender_last_tsn;
+                    Box::new(request) as Box<dyn Param + Send + Sync>
+                } else {
+                    param.clone()
+                }
+            })
+        }
+
+        ChunkReconfig {
+            param_a: update(&c.param_a, sender_last_tsn),
+            param_b: update(&c.param_b, sender_last_tsn),
+        }
+    }
+
+    fn reconfig_has_pending_data(&self, rsn: u32) -> bool {
+        self.reconfigs.get(&rsn).is_some_and(|c| {
+            Self::reconfig_stream_ids(c)
+                .iter()
+                .any(|id| self.pending_queue.contains_stream(*id))
+        })
+    }
+
+    fn refresh_unsent_reconfig(&mut self, rsn: u32) -> Option<Packet> {
+        let sender_last_tsn = self.my_next_tsn.wrapping_sub(1);
+        let reconfig = self
+            .reconfigs
+            .get(&rsn)
+            .map(|c| Self::reconfig_with_sender_last_tsn(c, sender_last_tsn))?;
+        self.reconfigs.insert(rsn, reconfig.clone());
+        Some(self.create_packet(vec![Box::new(reconfig)]))
     }
 
     /// Finish the one request associated with the running Re-configuration Timer.
@@ -1108,6 +1157,9 @@ impl Association {
     ) {
         // RFC 4960 §13.2: peer_last_tsn is the peer's initial TSN minus one.
         self.peer_last_tsn = initial_tsn.wrapping_sub(1);
+        // RFC 6525 §4: the peer's first request sequence number is its initial
+        // TSN, so A4's initial response value is one less than that.
+        self.peer_last_reconfig_rsn = initial_tsn.wrapping_sub(1);
 
         self.rwnd = advertised_receiver_window_credit;
         debug!("[{}] initial rwnd={}", self.side, self.rwnd);
@@ -1988,6 +2040,7 @@ impl Association {
                 reply.push(packet);
                 return Ok(());
             }
+            self.peer_last_reconfig_rsn = seq;
             self.reconfig_requests
                 .insert(p.reconfig_request_sequence_number, p.clone());
             self.reset_streams_if_any(p, true, reply)?;
@@ -2369,7 +2422,7 @@ impl Association {
         // abandoned (on_retransmission_failure).
         if !sis_to_reset.is_empty() {
             let rsn = self.generate_next_rsn();
-            let tsn = self.my_next_tsn - 1;
+            let tsn = self.my_next_tsn.wrapping_sub(1);
 
             let c = ChunkReconfig {
                 param_a: Some(Box::new(ParamOutgoingResetRequest {
@@ -2432,17 +2485,13 @@ impl Association {
         accept: bool,
         default_payload_type: PayloadProtocolIdentifier,
     ) -> Option<Stream<'_>> {
-        let mut s = StreamState::new(
+        let s = StreamState::new(
             self.side,
             stream_identifier,
             self.max_payload_size,
             self.max_receive_message_size,
             default_payload_type,
         );
-
-        if accept && self.stream_reset_blocked(stream_identifier) {
-            s.state = RecvSendState::Readable;
-        }
 
         if accept {
             self.stream_queue.push_back(stream_identifier);
@@ -2487,8 +2536,42 @@ impl Association {
     /// gather_outbound gathers outgoing packets. The returned bool value set to
     /// false means the association should be closed down after the final send.
     fn gather_outbound(&mut self, now: Instant) -> (Vec<Bytes>, bool) {
-        let mut raw_packets = vec![];
+        let mut raw_packets = self.gather_outbound_control_packets(vec![], now);
 
+        let state = self.state();
+        match state {
+            AssociationState::Established => {
+                raw_packets = self.gather_data_packets_to_retransmit(raw_packets, now);
+                raw_packets = self.gather_outbound_data_and_reconfig_packets(raw_packets, now);
+                // A queued reciprocal reset may have been held back until the
+                // DATA it covers received TSNs above. Give it another chance in
+                // this same poll so DATA and RE-CONFIG can leave together.
+                raw_packets = self.gather_outbound_control_packets(raw_packets, now);
+                raw_packets = self.gather_outbound_fast_retransmission_packets(raw_packets, now);
+                raw_packets = self.gather_outbound_sack_packets(raw_packets);
+                raw_packets = self.gather_outbound_forward_tsn_packets(raw_packets);
+                (raw_packets, true)
+            }
+            AssociationState::ShutdownPending
+            | AssociationState::ShutdownSent
+            | AssociationState::ShutdownReceived => {
+                raw_packets = self.gather_data_packets_to_retransmit(raw_packets, now);
+                raw_packets = self.gather_outbound_fast_retransmission_packets(raw_packets, now);
+                raw_packets = self.gather_outbound_sack_packets(raw_packets);
+                self.gather_outbound_shutdown_packets(raw_packets, now)
+            }
+            AssociationState::ShutdownAckSent => {
+                self.gather_outbound_shutdown_packets(raw_packets, now)
+            }
+            _ => (raw_packets, true),
+        }
+    }
+
+    fn gather_outbound_control_packets(
+        &mut self,
+        mut raw_packets: Vec<Bytes>,
+        now: Instant,
+    ) -> Vec<Bytes> {
         if !self.control_queue.is_empty() {
             let mut buffered = VecDeque::new();
             let queued = core::mem::take(&mut self.control_queue);
@@ -2501,6 +2584,19 @@ impl Association {
                     buffered.push_back(p);
                     continue;
                 }
+
+                // The reset boundary cannot be fixed until all already-queued
+                // DATA for the affected streams has received a TSN.
+                if outgoing_rsn.is_some_and(|rsn| self.reconfig_has_pending_data(rsn)) {
+                    buffered.push_back(p);
+                    continue;
+                }
+
+                let p = if let Some(rsn) = outgoing_rsn {
+                    self.refresh_unsent_reconfig(rsn).unwrap_or(p)
+                } else {
+                    p
+                };
 
                 match p.marshal() {
                     Ok(raw) => {
@@ -2521,29 +2617,12 @@ impl Association {
             self.control_queue = buffered;
         }
 
-        let state = self.state();
-        match state {
-            AssociationState::Established => {
-                raw_packets = self.gather_data_packets_to_retransmit(raw_packets, now);
-                raw_packets = self.gather_outbound_data_and_reconfig_packets(raw_packets, now);
-                raw_packets = self.gather_outbound_fast_retransmission_packets(raw_packets, now);
-                raw_packets = self.gather_outbound_sack_packets(raw_packets);
-                raw_packets = self.gather_outbound_forward_tsn_packets(raw_packets);
-                (raw_packets, true)
-            }
-            AssociationState::ShutdownPending
-            | AssociationState::ShutdownSent
-            | AssociationState::ShutdownReceived => {
-                raw_packets = self.gather_data_packets_to_retransmit(raw_packets, now);
-                raw_packets = self.gather_outbound_fast_retransmission_packets(raw_packets, now);
-                raw_packets = self.gather_outbound_sack_packets(raw_packets);
-                self.gather_outbound_shutdown_packets(raw_packets, now)
-            }
-            AssociationState::ShutdownAckSent => {
-                self.gather_outbound_shutdown_packets(raw_packets, now)
-            }
-            _ => (raw_packets, true),
+        if self.active_reconfig.is_some() {
+            self.timers
+                .restart_if_stale(Timer::Reconfig, now, self.rto_mgr.get_rto());
         }
+
+        raw_packets
     }
 
     fn gather_data_packets_to_retransmit(
@@ -2609,12 +2688,28 @@ impl Association {
         // RFC 6525 section 5.1.1 permits only one request in flight. Keep
         // application resets separate from DATA until that request completes.
         if self.active_reconfig.is_none()
-            && self.pending_queue.is_empty()
+            && self.reconfigs.is_empty()
             && !self.pending_reset_streams.is_empty()
         {
-            let stream_ids: Vec<_> = self.pending_reset_streams.drain(..).collect();
+            // DATA on an unrelated stream must not starve a reset, nor should
+            // one busy stream hold back ready reset requests for other streams.
+            let pending_queue = &self.pending_queue;
+            let mut stream_ids = vec![];
+            self.pending_reset_streams.retain(|id| {
+                if pending_queue.contains_stream(*id) {
+                    true
+                } else {
+                    stream_ids.push(*id);
+                    false
+                }
+            });
+
+            if stream_ids.is_empty() {
+                return raw_packets;
+            }
+
             let rsn = self.generate_next_rsn();
-            let tsn = self.my_next_tsn - 1;
+            let tsn = self.my_next_tsn.wrapping_sub(1);
             debug!(
                 "[{}] sending RECONFIG: rsn={} tsn={} streams={:?}",
                 self.side, rsn, tsn, stream_ids
@@ -2623,9 +2718,9 @@ impl Association {
             let c = ChunkReconfig {
                 param_a: Some(Box::new(ParamOutgoingResetRequest {
                     reconfig_request_sequence_number: rsn,
+                    reconfig_response_sequence_number: self.peer_last_reconfig_rsn,
                     sender_last_tsn: tsn,
                     stream_identifiers: stream_ids,
-                    ..Default::default()
                 })),
                 ..Default::default()
             };
@@ -2969,14 +3064,14 @@ impl Association {
     /// generate_next_tsn returns the my_next_tsn and increases it. The caller should hold the lock.
     fn generate_next_tsn(&mut self) -> u32 {
         let tsn = self.my_next_tsn;
-        self.my_next_tsn += 1;
+        self.my_next_tsn = self.my_next_tsn.wrapping_add(1);
         tsn
     }
 
     /// generate_next_rsn returns the my_next_rsn and increases it. The caller should hold the lock.
     fn generate_next_rsn(&mut self) -> u32 {
         let rsn = self.my_next_rsn;
-        self.my_next_rsn += 1;
+        self.my_next_rsn = self.my_next_rsn.wrapping_add(1);
         rsn
     }
 

--- a/src/association/mod.rs
+++ b/src/association/mod.rs
@@ -1308,10 +1308,18 @@ impl Association {
         });
 
         if !has_readable_data {
+            self.deferred_forward_tsns.remove(&stream_identifier);
             self.unregister_stream(stream_identifier, true);
             return;
         }
 
+        if let Some(updates) = self.deferred_forward_tsns.get_mut(&stream_identifier) {
+            for update in updates {
+                if update.generation_boundary.is_none() {
+                    update.generation_boundary = Some(sender_last_tsn);
+                }
+            }
+        }
         let mut boundaries = VecDeque::new();
         boundaries.push_back(sender_last_tsn);
         self.retiring_streams.insert(stream_identifier, boundaries);
@@ -1344,6 +1352,7 @@ impl Association {
                     .expect("retiring stream must have a current generation");
                 (completed, boundaries.front().copied())
             };
+            self.discard_deferred_forward_tsns_through(stream_identifier, completed_boundary);
             self.ready_stream_finishes.insert(stream_identifier);
 
             let Some(next_boundary) = next_boundary else {

--- a/src/association/mod.rs
+++ b/src/association/mod.rs
@@ -565,6 +565,10 @@ impl Association {
     #[must_use]
     pub fn poll(&mut self) -> Option<Event> {
         if let Some(x) = self.events.pop_front() {
+            if let Event::Stream(StreamEvent::ResetComplete { id }) = x {
+                self.reset_complete_streams.insert(id);
+                return Some(Event::Stream(StreamEvent::ResetComplete { id }));
+            }
             return Some(x);
         }
 
@@ -950,7 +954,11 @@ impl Association {
             // Other generations of the same id may still be pending or quarantined.
             if self.pending_reset_completions.contains(&id) {
                 self.pending_reset_completions.take_one(id);
-                self.reset_complete_streams.insert(id);
+                if let Some(stream) = self.streams.get_mut(&id) {
+                    if stream.state == RecvSendState::Readable {
+                        stream.state = RecvSendState::ReadWritable;
+                    }
+                }
                 self.events
                     .push_back(Event::Stream(StreamEvent::ResetComplete { id }));
             }
@@ -1887,8 +1895,13 @@ impl Association {
                         .map(|pa| pa.stream_identifiers.clone())
                         .unwrap_or_default();
                     self.emit_reset_complete(ids);
-                    if self.reconfigs.is_empty() {
+                    if self
+                        .reconfigs
+                        .keys()
+                        .all(|rsn| self.unsent_reconfigs.contains(rsn))
+                    {
                         self.timers.stop(Timer::Reconfig);
+                        self.awake_write_loop();
                     }
                 }
             }
@@ -1964,8 +1977,13 @@ impl Association {
                     _ => {}
                 }
             }
-            if self.reconfigs.is_empty() {
+            if self
+                .reconfigs
+                .keys()
+                .all(|rsn| self.unsent_reconfigs.contains(rsn))
+            {
                 self.timers.stop(Timer::Reconfig);
+                self.awake_write_loop();
             }
             Ok(())
         } else {
@@ -2373,13 +2391,20 @@ impl Association {
         accept: bool,
         default_payload_type: PayloadProtocolIdentifier,
     ) -> Option<Stream<'_>> {
-        let s = StreamState::new(
+        let mut s = StreamState::new(
             self.side,
             stream_identifier,
             self.max_payload_size,
             self.max_receive_message_size,
             default_payload_type,
         );
+
+        if accept
+            && (self.pending_reset_completions.contains(&stream_identifier)
+                || self.has_pending_reset_for_stream(stream_identifier))
+        {
+            s.state = RecvSendState::Readable;
+        }
 
         if accept {
             self.stream_queue.push_back(stream_identifier);
@@ -2427,17 +2452,39 @@ impl Association {
         let mut raw_packets = vec![];
 
         if !self.control_queue.is_empty() {
-            for p in self.control_queue.drain(..) {
+            let mut buffered = VecDeque::new();
+            let timer_running = self.timers.get(Timer::Reconfig).is_some();
+            let queued = core::mem::take(&mut self.control_queue);
+            for p in queued {
+                let outgoing_rsn = p.chunks.iter().find_map(|chunk| {
+                    chunk
+                        .as_any()
+                        .downcast_ref::<ChunkReconfig>()
+                        .and_then(|reconfig| reconfig.param_a.as_ref())
+                        .and_then(|param| {
+                            param.as_any().downcast_ref::<ParamOutgoingResetRequest>()
+                        })
+                        .map(|request| request.reconfig_request_sequence_number)
+                });
+
+                if timer_running
+                    && outgoing_rsn.is_some_and(|rsn| self.unsent_reconfigs.contains(&rsn))
+                {
+                    buffered.push_back(p);
+                    continue;
+                }
+
                 if let Ok(raw) = p.marshal() {
                     raw_packets.push(raw);
+                    if let Some(rsn) = outgoing_rsn {
+                        self.unsent_reconfigs.remove(&rsn);
+                    }
                 } else {
                     warn!("[{}] failed to serialize a control packet", self.side);
                     continue;
                 }
             }
-            // Reciprocal RE-CONFIG requests are queued as control packets. Once
-            // the queue is drained by poll_transmit, those RSNs are acknowledgeable.
-            self.unsent_reconfigs.clear();
+            self.control_queue = buffered;
         }
 
         let state = self.state();
@@ -2571,7 +2618,11 @@ impl Association {
         // Reconfigs can be inserted via reset_streams_if_any (incoming reset
         // response path) without going through the sis_to_reset / retransmit
         // block above.
-        if !self.reconfigs.is_empty() {
+        if self
+            .reconfigs
+            .keys()
+            .any(|rsn| !self.unsent_reconfigs.contains(rsn))
+        {
             self.timers
                 .restart_if_stale(Timer::Reconfig, now, self.rto_mgr.get_rto());
         }

--- a/src/association/stream.rs
+++ b/src/association/stream.rs
@@ -319,16 +319,13 @@ impl<'a> Stream<'a> {
         // stop() promises that future reads are not permitted. If a reset was
         // preserving unread boundary DATA, discard that old generation now so
         // its Finished event and unrelated association events cannot stall.
-        while self
+        if self
             .association
             .retiring_streams
             .contains_key(&self.stream_identifier)
         {
             self.association
-                .finish_retiring_stream(self.stream_identifier)?;
-            if let Some(s) = self.association.streams.get_mut(&self.stream_identifier) {
-                s.state = ((s.state as u8) & 0x2).into();
-            }
+                .discard_retiring_streams(self.stream_identifier);
         }
 
         Ok(())
@@ -520,27 +517,6 @@ impl StreamState {
 
     pub(crate) fn handle_data(&mut self, pd: &ChunkPayloadData) -> Result<bool> {
         self.reassembly_queue.push(pd.clone())
-    }
-
-    pub(crate) fn handle_forward_tsn_for_ordered(&mut self, ssn: u16) {
-        if self.unordered {
-            return; // unordered chunks are handled by handleForwardUnordered method
-        }
-
-        // Remove all chunks older than or equal to the new TSN from
-        // the reassembly_queue.
-        self.reassembly_queue.forward_tsn_for_ordered(ssn);
-    }
-
-    pub(crate) fn handle_forward_tsn_for_unordered(&mut self, new_cumulative_tsn: u32) {
-        if !self.unordered {
-            return; // ordered chunks are handled by handleForwardTSNOrdered method
-        }
-
-        // Remove all chunks older than or equal to the new TSN from
-        // the reassembly_queue.
-        self.reassembly_queue
-            .forward_tsn_for_unordered(new_cumulative_tsn);
     }
 
     fn packetize(

--- a/src/association/stream.rs
+++ b/src/association/stream.rs
@@ -15,6 +15,16 @@ use log::{debug, error, trace};
 /// Identifier for a stream within a particular association
 pub type StreamId = u16;
 
+/// Why a stream reset did not complete successfully.
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum StreamResetError {
+    /// The peer explicitly denied the reset request.
+    Denied,
+    /// The reset failed because of a protocol error or exhausted retransmissions.
+    Failed,
+}
+
 /// Application events about streams
 #[non_exhaustive]
 #[derive(Debug, PartialEq, Eq)]
@@ -42,18 +52,30 @@ pub enum StreamEvent {
     ///
     /// No more data can be read from or written to it.
     ///
-    /// Once this fires, [`StreamEvent::ResetComplete`] for the same id is
-    /// guaranteed to eventually follow, unless the association closes first.
+    /// Once this fires, either [`StreamEvent::ResetComplete`] or
+    /// [`StreamEvent::ResetFailed`] for the same id is guaranteed to eventually
+    /// follow, unless the association closes first.
     Finished {
         /// Which stream has been finished
         id: StreamId,
     },
-    /// The reset handshake involving this stream id has fully
-    /// completed and the id can be reused and
-    /// `[Association::open_stream]` stop failing.
+    /// A reset handshake involving this stream id completed successfully.
+    ///
+    /// The id can be reused unless a newer reset for the same id has since
+    /// started or failed.
     ResetComplete {
-        /// Which stream id has become reusable
+        /// Which stream id completed its reset.
         id: StreamId,
+    },
+    /// A reset handshake involving this stream id did not complete.
+    ///
+    /// The id remains unavailable for reuse until a later reset succeeds or
+    /// the association closes.
+    ResetFailed {
+        /// Which stream id failed to reset.
+        id: StreamId,
+        /// Why the reset did not complete.
+        reason: StreamResetError,
     },
     /// The peer asked us to stop sending on an outgoing stream
     Stopped {
@@ -234,6 +256,14 @@ impl<'a> Stream<'a> {
     }
 
     pub fn is_writable(&self) -> bool {
+        // RFC 6525 section 5.1.2 A1 forbids assigning new SSNs while an
+        // Outgoing SSN Reset Request for this stream is pending.
+        if self
+            .association
+            .stream_reset_in_progress(self.stream_identifier)
+        {
+            return false;
+        }
         if let Some(s) = self.association.streams.get(&self.stream_identifier) {
             s.state == RecvSendState::Writable || s.state == RecvSendState::ReadWritable
         } else {
@@ -245,7 +275,8 @@ impl<'a> Stream<'a> {
     /// Future calls to read are not permitted after calling stop.
     ///    
     /// NOTE: a stream closed without a queued reset never produces
-    /// `StreamEvent::Finished` / `StreamEvent::ResetComplete`.
+    /// `StreamEvent::Finished` followed by `StreamEvent::ResetComplete` or
+    /// `StreamEvent::ResetFailed`.
     pub fn stop(&mut self) -> Result<()> {
         let reset = self
             .association

--- a/src/association/stream.rs
+++ b/src/association/stream.rs
@@ -257,10 +257,12 @@ impl<'a> Stream<'a> {
 
     pub fn is_writable(&self) -> bool {
         // RFC 6525 section 5.1.2 A1 forbids assigning new SSNs while an
-        // Outgoing SSN Reset Request for this stream is pending.
+        // Outgoing SSN Reset Request for this stream is pending. A failed
+        // reset also quarantines the outgoing direction because the peer may
+        // already have reset its corresponding incoming stream.
         if self
             .association
-            .stream_reset_in_progress(self.stream_identifier)
+            .stream_reset_blocked(self.stream_identifier)
         {
             return false;
         }

--- a/src/association/stream.rs
+++ b/src/association/stream.rs
@@ -300,7 +300,11 @@ impl<'a> Stream<'a> {
                 s.state == RecvSendState::Readable || s.state == RecvSendState::ReadWritable
             });
 
-        if reset {
+        if reset
+            && !self
+                .association
+                .stream_reset_in_progress(self.stream_identifier)
+        {
             // Reset the outgoing stream
             // https://tools.ietf.org/html/rfc6525
             //

--- a/src/association/stream.rs
+++ b/src/association/stream.rs
@@ -150,13 +150,25 @@ impl<'a> Stream<'a> {
     /// Returns EOF when the stream is reset or an error if the stream is closed
     /// otherwise.
     pub fn read_sctp(&mut self) -> Result<Option<Chunks>> {
-        if let Some(s) = self.association.streams.get_mut(&self.stream_identifier) {
-            if s.state == RecvSendState::ReadWritable || s.state == RecvSendState::Readable {
-                return Ok(s.reassembly_queue.read());
-            }
+        let (message, drained) =
+            if let Some(s) = self.association.streams.get_mut(&self.stream_identifier) {
+                if s.state != RecvSendState::ReadWritable && s.state != RecvSendState::Readable {
+                    return Err(Error::ErrStreamClosed);
+                }
+
+                let message = s.reassembly_queue.read();
+                let drained = message.is_some() && s.reassembly_queue.get_num_bytes() == 0;
+                (message, drained)
+            } else {
+                return Err(Error::ErrStreamClosed);
+            };
+
+        if drained {
+            self.association
+                .finish_retiring_stream(self.stream_identifier)?;
         }
 
-        Err(Error::ErrStreamClosed)
+        Ok(message)
     }
 
     /// write_sctp writes len(p) bytes from p to the DTLS connection

--- a/src/association/stream.rs
+++ b/src/association/stream.rs
@@ -292,6 +292,10 @@ impl<'a> Stream<'a> {
     /// `StreamEvent::Finished` followed by `StreamEvent::ResetComplete` or
     /// `StreamEvent::ResetFailed`.
     pub fn stop(&mut self) -> Result<()> {
+        let retiring = self
+            .association
+            .retiring_streams
+            .contains_key(&self.stream_identifier);
         let reset = self
             .association
             .streams
@@ -301,6 +305,7 @@ impl<'a> Stream<'a> {
             });
 
         if reset
+            && !retiring
             && !self
                 .association
                 .stream_reset_in_progress(self.stream_identifier)
@@ -323,11 +328,7 @@ impl<'a> Stream<'a> {
         // stop() promises that future reads are not permitted. If a reset was
         // preserving unread boundary DATA, discard that old generation now so
         // its Finished event and unrelated association events cannot stall.
-        if self
-            .association
-            .retiring_streams
-            .contains_key(&self.stream_identifier)
-        {
+        if retiring {
             self.association
                 .discard_retiring_streams(self.stream_identifier);
         }

--- a/src/association/stream.rs
+++ b/src/association/stream.rs
@@ -319,13 +319,16 @@ impl<'a> Stream<'a> {
         // stop() promises that future reads are not permitted. If a reset was
         // preserving unread boundary DATA, discard that old generation now so
         // its Finished event and unrelated association events cannot stall.
-        if self
+        while self
             .association
             .retiring_streams
             .contains_key(&self.stream_identifier)
         {
             self.association
                 .finish_retiring_stream(self.stream_identifier)?;
+            if let Some(s) = self.association.streams.get_mut(&self.stream_identifier) {
+                s.state = ((s.state as u8) & 0x2).into();
+            }
         }
 
         Ok(())

--- a/src/association/stream.rs
+++ b/src/association/stream.rs
@@ -316,6 +316,18 @@ impl<'a> Stream<'a> {
             s.state = ((s.state as u8) & 0x2).into();
         }
 
+        // stop() promises that future reads are not permitted. If a reset was
+        // preserving unread boundary DATA, discard that old generation now so
+        // its Finished event and unrelated association events cannot stall.
+        if self
+            .association
+            .retiring_streams
+            .contains_key(&self.stream_identifier)
+        {
+            self.association
+                .finish_retiring_stream(self.stream_identifier)?;
+        }
+
         Ok(())
     }
 

--- a/src/chunk/chunk_reconfig.rs
+++ b/src/chunk/chunk_reconfig.rs
@@ -1,4 +1,5 @@
 use super::{chunk_header::*, chunk_type::*, *};
+use crate::param::param_type::ParamType;
 use crate::param::{param_header::*, *};
 use crate::util::get_padding_size;
 
@@ -106,7 +107,26 @@ impl Chunk for ChunkReconfig {
     }
 
     fn check(&self) -> Result<()> {
-        Ok(())
+        let param_a = self
+            .param_a
+            .as_ref()
+            .ok_or(Error::ErrChunkReconfigInvalidParamA)?;
+        let Some(param_b) = &self.param_b else {
+            return Ok(());
+        };
+
+        let combination = (param_a.header().typ, param_b.header().typ);
+        if matches!(
+            combination,
+            (ParamType::OutSsnResetReq, ParamType::IncSsnResetReq)
+                | (ParamType::AddOutStreamsReq, ParamType::AddIncStreamsReq)
+                | (ParamType::ReconfigResp, ParamType::OutSsnResetReq)
+                | (ParamType::ReconfigResp, ParamType::ReconfigResp)
+        ) {
+            Ok(())
+        } else {
+            Err(Error::ErrChunkReconfigInvalidParamCombination)
+        }
     }
 
     fn value_length(&self) -> usize {

--- a/src/endpoint/endpoint_test.rs
+++ b/src/endpoint/endpoint_test.rs
@@ -2736,10 +2736,17 @@ fn test_assoc_reset_inprogress_completed_via_tsn_advance_then_retransmit() -> Re
     }
     pair.drive();
 
-    // The reset should have completed via TSN advance — stream 1 gone.
+    // The boundary DATA must remain readable even though the reset completed.
+    // Draining it retires the old stream generation.
+    let boundary_data = pair
+        .server_stream(server_ch, si)?
+        .read()?
+        .expect("boundary DATA should survive the reset");
+    assert_eq!(boundary_data.len(), b"payload".len());
+
     assert!(
         pair.server_stream(server_ch, si).is_err(),
-        "stream should be reset after TSN advance completes the InProgress request"
+        "stream should retire after its boundary DATA is drained"
     );
 
     // Step 3: Reopen stream 1 with the same ID.
@@ -2847,10 +2854,17 @@ fn test_assoc_reset_inprogress_reconfig_retransmission() -> Result<()> {
     // Let everything settle.
     pair.drive();
 
-    // The reset should have completed — stream 1 should be gone.
+    // The boundary DATA must remain readable even though the reset completed.
+    // Draining it retires the old stream generation.
+    let boundary_data = pair
+        .server_stream(server_ch, si)?
+        .read()?
+        .expect("boundary DATA should survive the reset");
+    assert_eq!(boundary_data.len(), b"payload".len());
+
     assert!(
         pair.server_stream(server_ch, si).is_err(),
-        "stream should be reset after InProgress retransmission completes"
+        "stream should retire after its boundary DATA is drained"
     );
 
     Ok(())

--- a/src/endpoint/endpoint_test.rs
+++ b/src/endpoint/endpoint_test.rs
@@ -2905,7 +2905,7 @@ fn test_assoc_open_stream_rejects_pending_reset_id() -> Result<()> {
 }
 
 #[test]
-fn test_assoc_reconfig_failure_clears_pending() -> Result<()> {
+fn test_assoc_reconfig_failure_keeps_stream_quarantined() -> Result<()> {
     let si: u16 = 1;
 
     let (mut pair, client_ch, server_ch) = create_association_pair(AckMode::NoDelay, 0)?;
@@ -2946,15 +2946,13 @@ fn test_assoc_reconfig_failure_clears_pending() -> Result<()> {
         pair.server.inbound.clear();
     }
 
-    // After retransmission failure, reconfigs should be cleared and the stream
-    // ID should be available for reuse.
-    let _ = pair
-        .client_conn_mut(client_ch)
-        .open_stream(si, PayloadProtocolIdentifier::Binary)?;
-    assert!(
-        pair.client_stream(client_ch, si).is_ok(),
-        "stream 1 should be available after reconfig retransmission failure"
-    );
+    // The in-flight request is abandoned, but without a terminal success the
+    // stream ID remains quarantined and must not be reused.
+    assert!(matches!(
+        pair.client_conn_mut(client_ch)
+            .open_stream(si, PayloadProtocolIdentifier::Binary),
+        Err(Error::ErrStreamResetPending)
+    ));
 
     Ok(())
 }

--- a/src/endpoint/endpoint_test.rs
+++ b/src/endpoint/endpoint_test.rs
@@ -9,7 +9,7 @@ use crate::config::generate_snap_token;
 use crate::error::{Error, Result};
 
 use crate::association::state::{AckMode, AssociationState};
-use crate::association::stream::{ReliabilityType, Stream};
+use crate::association::stream::{ReliabilityType, Stream, StreamEvent, StreamResetError};
 use crate::chunk::chunk_abort::ChunkAbort;
 use crate::chunk::chunk_cookie_echo::ChunkCookieEcho;
 use crate::chunk::chunk_error::ChunkError;
@@ -2945,6 +2945,17 @@ fn test_assoc_reconfig_failure_keeps_stream_quarantined() -> Result<()> {
         pair.drive_client();
         pair.server.inbound.clear();
     }
+
+    assert!(
+        core::iter::from_fn(|| pair.client_conn_mut(client_ch).poll()).any(|event| matches!(
+            event,
+            Event::Stream(StreamEvent::ResetFailed {
+                id,
+                reason: StreamResetError::Failed,
+            }) if id == si
+        )),
+        "reset retransmission exhaustion should emit a terminal failure event"
+    );
 
     // The in-flight request is abandoned, but without a terminal success the
     // stream ID remains quarantined and must not be reused.

--- a/src/error.rs
+++ b/src/error.rs
@@ -119,6 +119,8 @@ pub enum Error {
     ErrChunkTypeNotReconfig,
     #[error("ChunkReconfig has invalid ParamA")]
     ErrChunkReconfigInvalidParamA,
+    #[error("ChunkReconfig has an unsupported parameter combination")]
+    ErrChunkReconfigInvalidParamCombination,
 
     #[error("failed to parse param type")]
     ErrChunkParseParamTypeFailed,

--- a/src/error.rs
+++ b/src/error.rs
@@ -78,6 +78,8 @@ pub enum Error {
     ErrParamPacketTooShort,
     #[error("outgoing SSN reset request parameter too short")]
     ErrSsnResetRequestParamTooShort,
+    #[error("outgoing SSN reset request parameter has an invalid length")]
+    ErrSsnResetRequestParamInvalidLength,
     #[error("reconfig response parameter too short")]
     ErrReconfigRespParamTooShort,
     #[error("invalid algorithm type")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,7 +65,9 @@ pub use crate::association::Association;
 pub use crate::association::AssociationError;
 pub use crate::association::Event;
 pub use crate::association::stats::AssociationStats;
-pub use crate::association::stream::{ReliabilityType, Stream, StreamEvent, StreamId, StreamState};
+pub use crate::association::stream::{
+    ReliabilityType, Stream, StreamEvent, StreamId, StreamResetError, StreamState,
+};
 
 pub(crate) mod chunk;
 pub use crate::chunk::ErrorCauseCode;

--- a/src/param/param_outgoing_reset_request.rs
+++ b/src/param/param_outgoing_reset_request.rs
@@ -54,8 +54,8 @@ impl fmt::Display for ParamOutgoingResetRequest {
             "{} {} {} {} {:?}",
             self.header(),
             self.reconfig_request_sequence_number,
-            self.reconfig_request_sequence_number,
             self.reconfig_response_sequence_number,
+            self.sender_last_tsn,
             self.stream_identifiers
         )
     }
@@ -73,6 +73,10 @@ impl Param for ParamOutgoingResetRequest {
         let header = ParamHeader::unmarshal(raw)?;
         if header.value_length() < PARAM_OUTGOING_RESET_REQUEST_STREAM_IDENTIFIERS_OFFSET {
             return Err(Error::ErrSsnResetRequestParamTooShort);
+        }
+        if (header.value_length() - PARAM_OUTGOING_RESET_REQUEST_STREAM_IDENTIFIERS_OFFSET) % 2 != 0
+        {
+            return Err(Error::ErrSsnResetRequestParamInvalidLength);
         }
 
         let reader =

--- a/src/param/param_test.rs
+++ b/src/param/param_test.rs
@@ -157,6 +157,13 @@ fn test_param_outgoing_reset_request_failure() -> Result<()> {
     let tests = vec![
         ("packet too short", CHUNK_RECONFIG_PARAM_A.slice(..8)),
         ("param too short", Bytes::from_static(&[0x0, 0xd, 0x0, 0x4])),
+        (
+            "odd stream identifier bytes",
+            Bytes::from_static(&[
+                0x0, 0xd, 0x0, 0x11, 0x0, 0x0, 0x0, 0x1, 0x0, 0x0, 0x0, 0x2, 0x0, 0x0, 0x0, 0x3,
+                0xff,
+            ]),
+        ),
     ];
 
     for (name, binary) in tests {

--- a/src/queue/pending_queue.rs
+++ b/src/queue/pending_queue.rs
@@ -110,4 +110,11 @@ impl PendingQueue {
     pub(crate) fn is_empty(&self) -> bool {
         self.len() == 0
     }
+
+    pub(crate) fn contains_stream(&self, stream_identifier: u16) -> bool {
+        self.unordered_queue
+            .iter()
+            .chain(self.ordered_queue.iter())
+            .any(|chunk| chunk.stream_identifier == stream_identifier)
+    }
 }

--- a/src/queue/reassembly_queue.rs
+++ b/src/queue/reassembly_queue.rs
@@ -457,6 +457,52 @@ impl ReassemblyQueue {
         }
     }
 
+    /// Apply an ordered Forward-TSN retained across a stream reset without
+    /// crossing into messages whose TSNs are newer than its cumulative point.
+    pub(crate) fn forward_tsn_for_ordered_bounded(
+        &mut self,
+        last_ssn: u16,
+        new_cumulative_tsn: u32,
+    ) {
+        let first_newer_ssn = self
+            .ordered
+            .iter()
+            .filter(|chunks| {
+                sna16lte(chunks.ssn, last_ssn)
+                    && chunks
+                        .chunks
+                        .iter()
+                        .any(|chunk| sna32gt(chunk.tsn, new_cumulative_tsn))
+            })
+            .map(|chunks| chunks.ssn)
+            .reduce(|first, candidate| {
+                if sna16lt(candidate, first) {
+                    candidate
+                } else {
+                    first
+                }
+            });
+
+        let is_forwarded = |ssn| {
+            sna16lte(ssn, last_ssn) && first_newer_ssn.is_none_or(|first| sna16lt(ssn, first))
+        };
+        let num_bytes = self
+            .ordered
+            .iter()
+            .filter(|chunks| is_forwarded(chunks.ssn) && !chunks.is_complete())
+            .flat_map(|chunks| chunks.chunks.iter())
+            .map(|chunk| chunk.user_data.len())
+            .sum();
+        self.subtract_num_bytes(num_bytes);
+        self.ordered
+            .retain(|chunks| !is_forwarded(chunks.ssn) || chunks.is_complete());
+
+        let next_ssn = first_newer_ssn.unwrap_or_else(|| last_ssn.wrapping_add(1));
+        if sna16lt(self.next_ssn, next_ssn) {
+            self.next_ssn = next_ssn;
+        }
+    }
+
     /// Remove all fragments in the unordered sets that contains chunks
     /// equal to or older than `new_cumulative_tsn`.
     /// We know all sets in the r.unordered are complete ones.

--- a/src/queue/reassembly_queue.rs
+++ b/src/queue/reassembly_queue.rs
@@ -536,7 +536,7 @@ impl ReassemblyQueue {
             || self
                 .ordered
                 .iter()
-                .any(|chunks| sna16lte(chunks.ssn, last_ssn))
+                .any(|chunks| chunks.ssn == self.next_ssn)
         {
             return true;
         }

--- a/src/queue/reassembly_queue.rs
+++ b/src/queue/reassembly_queue.rs
@@ -525,32 +525,36 @@ impl ReassemblyQueue {
         }
     }
 
-    /// Whether an ambiguous deferred ordered skip has enough TSN context to
-    /// advance without overtaking a still-missing successor message.
-    pub(crate) fn can_apply_forward_tsn_for_ordered_bounded(
+    /// The highest prefix of an ambiguous deferred ordered skip that has
+    /// enough TSN context to advance without overtaking a missing successor.
+    pub(crate) fn applicable_forward_tsn_for_ordered_bounded(
         &self,
         last_ssn: u16,
         new_cumulative_tsn: u32,
         peer_last_tsn: u32,
-    ) -> bool {
-        if sna16gt(self.next_ssn, last_ssn)
-            || self.ordered.iter().any(|chunks| {
-                chunks.ssn == last_ssn
-                    && (chunks.ssn == self.next_ssn
-                        || if chunks.is_complete() {
-                            chunks
-                                .chunks
-                                .iter()
-                                .all(|chunk| sna32lte(chunk.tsn, new_cumulative_tsn))
-                        } else {
-                            chunks.is_missing_tsn_at_or_before(new_cumulative_tsn)
-                        })
-            })
-        {
-            return true;
+    ) -> Option<u16> {
+        if sna16gt(self.next_ssn, last_ssn) {
+            return Some(last_ssn);
         }
 
-        self.ordered
+        let is_covered = |chunks: &Chunks| {
+            if chunks.is_complete() {
+                chunks
+                    .chunks
+                    .iter()
+                    .all(|chunk| sna32lte(chunk.tsn, new_cumulative_tsn))
+            } else {
+                chunks.is_missing_tsn_at_or_before(new_cumulative_tsn)
+            }
+        };
+        if self.ordered.iter().any(|chunks| {
+            chunks.ssn == last_ssn && (chunks.ssn == self.next_ssn || is_covered(chunks))
+        }) {
+            return Some(last_ssn);
+        }
+
+        let has_resolved_later_tsn = self
+            .ordered
             .iter()
             .filter(|chunks| chunks.ssn == last_ssn || sna16gt(chunks.ssn, last_ssn))
             .flat_map(|chunks| chunks.chunks.iter())
@@ -562,7 +566,26 @@ impl ReassemblyQueue {
                     first
                 }
             })
-            .is_some_and(|first_tsn| sna32lte(first_tsn, peer_last_tsn))
+            .is_some_and(|first_tsn| sna32lte(first_tsn, peer_last_tsn));
+        if has_resolved_later_tsn {
+            return Some(last_ssn);
+        }
+
+        self.ordered
+            .iter()
+            .filter(|chunks| {
+                (chunks.ssn == self.next_ssn || sna16gt(chunks.ssn, self.next_ssn))
+                    && sna16lt(chunks.ssn, last_ssn)
+                    && is_covered(chunks)
+            })
+            .map(|chunks| chunks.ssn)
+            .reduce(|last, candidate| {
+                if sna16gt(candidate, last) {
+                    candidate
+                } else {
+                    last
+                }
+            })
     }
 
     /// Remove all fragments in the unordered sets that contains chunks

--- a/src/queue/reassembly_queue.rs
+++ b/src/queue/reassembly_queue.rs
@@ -530,13 +530,22 @@ impl ReassemblyQueue {
     pub(crate) fn can_apply_forward_tsn_for_ordered_bounded(
         &self,
         last_ssn: u16,
+        new_cumulative_tsn: u32,
         peer_last_tsn: u32,
     ) -> bool {
         if sna16gt(self.next_ssn, last_ssn)
-            || self
-                .ordered
-                .iter()
-                .any(|chunks| chunks.ssn == self.next_ssn)
+            || self.ordered.iter().any(|chunks| {
+                chunks.ssn == self.next_ssn
+                    || (sna16lte(chunks.ssn, last_ssn)
+                        && if chunks.is_complete() {
+                            chunks
+                                .chunks
+                                .iter()
+                                .all(|chunk| sna32lte(chunk.tsn, new_cumulative_tsn))
+                        } else {
+                            chunks.is_missing_tsn_at_or_before(new_cumulative_tsn)
+                        })
+            })
         {
             return true;
         }

--- a/src/queue/reassembly_queue.rs
+++ b/src/queue/reassembly_queue.rs
@@ -505,19 +505,24 @@ impl ReassemblyQueue {
                 }
             });
 
-        let is_forwarded = |ssn| {
-            sna16lte(ssn, last_ssn) && first_unaffected_ssn.is_none_or(|first| sna16lt(ssn, first))
+        let is_abandoned_partial = |chunks: &&Chunks| {
+            sna16lte(chunks.ssn, last_ssn)
+                && !chunks.is_complete()
+                && chunks.is_missing_tsn_at_or_before(new_cumulative_tsn)
         };
         let num_bytes = self
             .ordered
             .iter()
-            .filter(|chunks| is_forwarded(chunks.ssn) && !chunks.is_complete())
+            .filter(is_abandoned_partial)
             .flat_map(|chunks| chunks.chunks.iter())
             .map(|chunk| chunk.user_data.len())
             .sum();
         self.subtract_num_bytes(num_bytes);
-        self.ordered
-            .retain(|chunks| !is_forwarded(chunks.ssn) || chunks.is_complete());
+        self.ordered.retain(|chunks| {
+            !sna16lte(chunks.ssn, last_ssn)
+                || chunks.is_complete()
+                || !chunks.is_missing_tsn_at_or_before(new_cumulative_tsn)
+        });
 
         let next_ssn = first_unaffected_ssn.unwrap_or_else(|| last_ssn.wrapping_add(1));
         if sna16lt(self.next_ssn, next_ssn) {

--- a/src/queue/reassembly_queue.rs
+++ b/src/queue/reassembly_queue.rs
@@ -576,7 +576,11 @@ impl ReassemblyQueue {
             .filter(|chunks| {
                 (chunks.ssn == self.next_ssn || sna16gt(chunks.ssn, self.next_ssn))
                     && sna16lt(chunks.ssn, last_ssn)
-                    && is_covered(chunks)
+                    && (is_covered(chunks)
+                        || chunks
+                            .chunks
+                            .first()
+                            .is_some_and(|chunk| sna32lte(chunk.tsn, peer_last_tsn)))
             })
             .map(|chunks| chunks.ssn)
             .reduce(|last, candidate| {

--- a/src/queue/reassembly_queue.rs
+++ b/src/queue/reassembly_queue.rs
@@ -535,9 +535,9 @@ impl ReassemblyQueue {
     ) -> bool {
         if sna16gt(self.next_ssn, last_ssn)
             || self.ordered.iter().any(|chunks| {
-                chunks.ssn == self.next_ssn
-                    || (sna16lte(chunks.ssn, last_ssn)
-                        && if chunks.is_complete() {
+                chunks.ssn == last_ssn
+                    && (chunks.ssn == self.next_ssn
+                        || if chunks.is_complete() {
                             chunks
                                 .chunks
                                 .iter()
@@ -552,7 +552,7 @@ impl ReassemblyQueue {
 
         self.ordered
             .iter()
-            .filter(|chunks| sna16gt(chunks.ssn, last_ssn))
+            .filter(|chunks| chunks.ssn == last_ssn || sna16gt(chunks.ssn, last_ssn))
             .flat_map(|chunks| chunks.chunks.iter())
             .map(|chunk| chunk.tsn)
             .reduce(|first, candidate| {

--- a/src/queue/reassembly_queue.rs
+++ b/src/queue/reassembly_queue.rs
@@ -175,6 +175,24 @@ impl Chunks {
 
         true
     }
+
+    fn is_missing_tsn_at_or_before(&self, cumulative_tsn: u32) -> bool {
+        let Some(first) = self.chunks.first() else {
+            return false;
+        };
+        if !first.beginning_fragment && sna32lte(first.tsn.wrapping_sub(1), cumulative_tsn) {
+            return true;
+        }
+        if self.chunks.windows(2).any(|pair| {
+            let missing_tsn = pair[0].tsn.wrapping_add(1);
+            missing_tsn != pair[1].tsn && sna32lte(missing_tsn, cumulative_tsn)
+        }) {
+            return true;
+        }
+
+        let last = self.chunks.last().expect("a first chunk exists");
+        !last.ending_fragment && sna32lte(last.tsn.wrapping_add(1), cumulative_tsn)
+    }
 }
 
 #[derive(Default, Debug)]
@@ -464,15 +482,19 @@ impl ReassemblyQueue {
         last_ssn: u16,
         new_cumulative_tsn: u32,
     ) {
-        let first_newer_ssn = self
+        let first_unaffected_ssn = self
             .ordered
             .iter()
             .filter(|chunks| {
                 sna16lte(chunks.ssn, last_ssn)
-                    && chunks
-                        .chunks
-                        .iter()
-                        .any(|chunk| sna32gt(chunk.tsn, new_cumulative_tsn))
+                    && if chunks.is_complete() {
+                        chunks
+                            .chunks
+                            .iter()
+                            .any(|chunk| sna32gt(chunk.tsn, new_cumulative_tsn))
+                    } else {
+                        !chunks.is_missing_tsn_at_or_before(new_cumulative_tsn)
+                    }
             })
             .map(|chunks| chunks.ssn)
             .reduce(|first, candidate| {
@@ -484,7 +506,7 @@ impl ReassemblyQueue {
             });
 
         let is_forwarded = |ssn| {
-            sna16lte(ssn, last_ssn) && first_newer_ssn.is_none_or(|first| sna16lt(ssn, first))
+            sna16lte(ssn, last_ssn) && first_unaffected_ssn.is_none_or(|first| sna16lt(ssn, first))
         };
         let num_bytes = self
             .ordered
@@ -497,10 +519,41 @@ impl ReassemblyQueue {
         self.ordered
             .retain(|chunks| !is_forwarded(chunks.ssn) || chunks.is_complete());
 
-        let next_ssn = first_newer_ssn.unwrap_or_else(|| last_ssn.wrapping_add(1));
+        let next_ssn = first_unaffected_ssn.unwrap_or_else(|| last_ssn.wrapping_add(1));
         if sna16lt(self.next_ssn, next_ssn) {
             self.next_ssn = next_ssn;
         }
+    }
+
+    /// Whether an ambiguous deferred ordered skip has enough TSN context to
+    /// advance without overtaking a still-missing successor message.
+    pub(crate) fn can_apply_forward_tsn_for_ordered_bounded(
+        &self,
+        last_ssn: u16,
+        peer_last_tsn: u32,
+    ) -> bool {
+        if sna16gt(self.next_ssn, last_ssn)
+            || self
+                .ordered
+                .iter()
+                .any(|chunks| sna16lte(chunks.ssn, last_ssn))
+        {
+            return true;
+        }
+
+        self.ordered
+            .iter()
+            .filter(|chunks| sna16gt(chunks.ssn, last_ssn))
+            .flat_map(|chunks| chunks.chunks.iter())
+            .map(|chunk| chunk.tsn)
+            .reduce(|first, candidate| {
+                if sna32lt(candidate, first) {
+                    candidate
+                } else {
+                    first
+                }
+            })
+            .is_some_and(|first_tsn| sna32lte(first_tsn, peer_last_tsn))
     }
 
     /// Remove all fragments in the unordered sets that contains chunks


### PR DESCRIPTION
## Summary

- serialize outgoing stream-reset requests behind one active Re-configuration Timer
- keep overlapping stream generations quarantined until their own terminal result
- report ResetComplete or ResetFailed and ignore stale acknowledgements
- prevent reset requests from overtaking queued DATA or assigning new SSNs while pending