### PR TITLE
fix: bound FORWARD-TSN cumulative advance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+  * Bound FORWARD-TSN cumulative advance to avoid pinning the CPU up to ~2^31 TSN jumps per chunk
+
 # 0.10.3
 
   * Fix stream reset completion, failure reporting, and request serialization #54

--- a/src/association/association_test.rs
+++ b/src/association/association_test.rs
@@ -3526,6 +3526,75 @@ fn test_handle_forward_tsn_dup_forward_tsn_chunk_should_generate_sack() -> Resul
     Ok(())
 }
 
+fn queued_chunk(tsn: u32) -> ChunkPayloadData {
+    ChunkPayloadData {
+        beginning_fragment: true,
+        ending_fragment: true,
+        tsn,
+        user_data: Bytes::from_static(b"ABC"),
+        ..Default::default()
+    }
+}
+
+/// A peer names `new_cumulative_tsn` freely, up to ~2^31 ahead in serial-number
+/// arithmetic. Advancing one TSN per iteration turned that into a multi-second
+/// hang per chunk; the cost must follow the queue, not the size of the jump.
+#[test]
+fn test_handle_forward_tsn_huge_gap_is_bounded() -> Result<()> {
+    let mut a = Association {
+        use_forward_tsn: true,
+        ..Default::default()
+    };
+    let gap: u32 = 1 << 30;
+
+    // One chunk the jump abandons, one beyond it that must survive.
+    assert!(a.payload_queue.push(queued_chunk(5), 0));
+    assert!(a.payload_queue.push(queued_chunk(gap + 5), 0));
+
+    let start = Instant::now();
+    a.handle_forward_tsn(&ChunkForwardTsn {
+        new_cumulative_tsn: gap,
+        streams: vec![],
+    })?;
+    let elapsed = start.elapsed();
+
+    assert!(
+        elapsed < Duration::from_secs(2),
+        "advance must be bounded by queued data, took {elapsed:?}"
+    );
+    assert_eq!(a.peer_last_tsn, gap, "should reach the new cumulative TSN");
+    assert!(a.payload_queue.get(5).is_none(), "abandoned chunk dropped");
+    assert!(a.payload_queue.get(gap + 5).is_some(), "later chunk kept");
+    assert_eq!(a.payload_queue.get_num_bytes(), 3, "bytes follow the drop");
+
+    Ok(())
+}
+
+/// The I-FORWARD-TSN handler (RFC 8260) carries its own copy of the advance.
+#[test]
+fn test_handle_i_forward_tsn_huge_gap_is_bounded() -> Result<()> {
+    let mut a = Association {
+        use_forward_tsn: true,
+        ..Default::default()
+    };
+    let gap: u32 = 1 << 30;
+
+    let start = Instant::now();
+    a.handle_i_forward_tsn(&ChunkIForwardTsn {
+        new_cumulative_tsn: gap,
+        streams: vec![],
+    })?;
+    let elapsed = start.elapsed();
+
+    assert!(
+        elapsed < Duration::from_secs(2),
+        "advance must be bounded by queued data, took {elapsed:?}"
+    );
+    assert_eq!(a.peer_last_tsn, gap, "should reach the new cumulative TSN");
+
+    Ok(())
+}
+
 #[test]
 fn test_assoc_create_new_stream() -> Result<()> {
     let mut a = Association::default();

--- a/src/association/mod.rs
+++ b/src/association/mod.rs
@@ -2626,15 +2626,10 @@ impl Association {
         //   its cumulative TSN point to the value carried in the FORWARD TSN
         //   chunk,
 
-        // Advance peer_last_tsn
-        while sna32lt(self.peer_last_tsn, c.new_cumulative_tsn) {
-            let next_tsn = self.peer_last_tsn.wrapping_add(1);
-            // Keep the reset-generation copy, if any. Applying the stream
-            // forwarding state after replay discards incomplete messages while
-            // preserving complete DATA already received above a TSN gap.
-            let _ = self.payload_queue.pop(next_tsn);
-            self.peer_last_tsn = next_tsn;
-        }
+        // Advance to the peer's new cumulative tsn point,
+        // dropping the chunks it abandoned along the way.
+        self.payload_queue.pop_up_to(c.new_cumulative_tsn);
+        self.peer_last_tsn = c.new_cumulative_tsn;
 
         // Report new peer_last_tsn value and abandoned largest SSN value to
         // corresponding streams so that the abandoned chunks can be removed
@@ -2690,15 +2685,10 @@ impl Association {
             return Ok(vec![]);
         }
 
-        // Advance peer_last_tsn
-        while sna32lt(self.peer_last_tsn, c.new_cumulative_tsn) {
-            let next_tsn = self.peer_last_tsn.wrapping_add(1);
-            // Keep the reset-generation copy, if any. Applying the stream
-            // forwarding state after replay discards incomplete messages while
-            // preserving complete DATA already received above a TSN gap.
-            let _ = self.payload_queue.pop(next_tsn);
-            self.peer_last_tsn = next_tsn;
-        }
+        // Advance to the peer's new cumulative tsn point,
+        // dropping the chunks it abandoned along the way.
+        self.payload_queue.pop_up_to(c.new_cumulative_tsn);
+        self.peer_last_tsn = c.new_cumulative_tsn;
 
         // Handle per-stream entries using the explicit unordered flag
         for forwarded in &c.streams {

--- a/src/queue/payload_queue.rs
+++ b/src/queue/payload_queue.rs
@@ -68,12 +68,33 @@ impl PayloadQueue {
             self.sorted.remove(0);
             if let Some(c) = self.chunk_map.remove(&tsn) {
                 //self.length -= 1;
-                self.n_bytes -= c.user_data.len();
+                self.n_bytes = self.n_bytes.saturating_sub(c.user_data.len());
                 return Some(c);
             }
         }
 
         None
+    }
+
+    /// Removes every queued chunk with a TSN at or before `cumulative_tsn`.
+    ///
+    /// Used when a FORWARD-TSN moves the cumulative TSN point past chunks the
+    /// peer abandoned. The cost is proportional to the number of queued chunks,
+    /// not to the size of the TSN jump: `cumulative_tsn` comes off the wire and
+    /// may be up to 2^31 ahead of the current point.
+    pub(crate) fn pop_up_to(&mut self, cumulative_tsn: u32) {
+        let chunk_map = &mut self.chunk_map;
+        let n_bytes = &mut self.n_bytes;
+        self.sorted.retain(|tsn| {
+            if sna32lte(*tsn, cumulative_tsn) {
+                if let Some(c) = chunk_map.remove(tsn) {
+                    *n_bytes = n_bytes.saturating_sub(c.user_data.len());
+                }
+                false
+            } else {
+                true
+            }
+        });
     }
 
     /// get returns reference to chunkPayloadData with the given TSN value.


### PR DESCRIPTION
FORWARD-TSN handlers advanced peer_last_tsn one TSN per iteration up to the peer-supplied new_cumulative_tsn, which may be ~2^31 ahead, about 650ms of pinned CPU per chunk in a release build, repeatable.